### PR TITLE
Handle Codex usage-limit completion

### DIFF
--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -182,6 +182,10 @@ class AgentMonitor:
             collected_at=now,
         )
 
+    def latest_statuses(self) -> tuple[AgentStatus, ...]:
+        """Return the newest parsed status for each agent, including stale ones."""
+        return tuple(self._latest_statuses().values())
+
     def _latest_statuses(self) -> dict[str, AgentStatus]:
         signature = self._input_signature()
         if (
@@ -421,6 +425,20 @@ class LiveAgentMonitor:
                 return
             self.statuses_by_key[status.agent_id] = status
             self.write_latest_state()
+
+    def reconcile_statuses(self, statuses: Iterable[AgentStatus]) -> int:
+        """Merge newer fallback statuses without overriding newer live events."""
+        changed = 0
+        with self.lock:
+            for status in statuses:
+                previous = self.statuses_by_key.get(status.agent_id)
+                if previous is not None and previous.updated_at >= status.updated_at:
+                    continue
+                self.statuses_by_key[status.agent_id] = status
+                changed += 1
+            if changed:
+                self.write_latest_state()
+        return changed
 
     def snapshot(self, include_stale: bool = False) -> MonitorSnapshot:
         now = datetime.now(timezone.utc)
@@ -685,7 +703,11 @@ def codex_transcript_event(
         )
 
     if payload_type == "task_complete":
-        message = _string_or_none(payload.get("last_agent_message")) or ""
+        error = payload.get("error")
+        error_message = (
+            _string_or_none(error.get("message")) if isinstance(error, dict) else None
+        )
+        message = _string_or_none(payload.get("last_agent_message")) or error_message or ""
         return HookEvent(
             provider="codex",
             logged_at=timestamp,
@@ -696,6 +718,7 @@ def codex_transcript_event(
                 "turn_id": turn_id,
                 "cwd": cwd,
                 "last_assistant_message": message,
+                "error": error,
                 "transcript_path": str(path),
                 "source": CODEX_TRANSCRIPT_PROVIDER,
             },

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -80,7 +80,13 @@ from .audit import (
     read_status_history_records,
     status_history_record,
 )
-from .collector import LiveAgentMonitor, SourceSpec
+from .collector import (
+    CODEX_TRANSCRIPT_PROVIDER,
+    AgentMonitor,
+    LiveAgentMonitor,
+    SourceSpec,
+    read_recent_lines,
+)
 from .device_writer import (
     DEFAULT_FILE_NAME,
     MOUNT_ROOT,
@@ -134,6 +140,7 @@ from .providers import (
     detect_claude_config,
     detect_codex_config,
     detect_grok_config,
+    detect_log_path,
     default_state_dir,
     parse_log_line,
 )
@@ -508,6 +515,40 @@ def format_percent_value(value: float | int) -> str:
     return f"{number:.1f}%"
 
 
+def reconcile_codex_terminal_transcripts(
+    monitor: LiveAgentMonitor,
+    transcript_monitor: AgentMonitor,
+) -> int:
+    """Recover terminal Codex states that can be omitted from live hooks."""
+    terminal = (
+        status
+        for status in transcript_monitor.latest_statuses()
+        if status.provider == "codex" and status.event_name == "Stop"
+    )
+    return monitor.reconcile_statuses(terminal)
+
+
+def replay_recent_debug_logs(
+    monitor: LiveAgentMonitor,
+    *,
+    providers: tuple[str, ...] = ("codex", "claude", "grok"),
+    max_lines: int = 200,
+) -> int:
+    replayed = 0
+    for provider in providers:
+        try:
+            path = detect_log_path(provider)
+            lines = read_recent_lines(path, max_lines) if path.exists() else []
+        except Exception:
+            continue
+        for line in lines:
+            record = parse_log_line(provider, line)
+            if record is not None:
+                monitor.ingest_record(record)
+                replayed += 1
+    return replayed
+
+
 class StatusBarController(NSObject):
     def init(self):
         self = objc.super(StatusBarController, self).init()
@@ -516,6 +557,7 @@ class StatusBarController(NSObject):
 
         self.settings = load_settings()
         self.monitor = self.build_monitor()
+        self.codex_terminal_monitor = self.build_codex_terminal_monitor()
         self.event_server = None
         self.status_item = None
         self.timer = None
@@ -636,6 +678,10 @@ class StatusBarController(NSObject):
     @objc.IBAction
     def refresh_(self, _sender):
         try:
+            reconcile_codex_terminal_transcripts(
+                self.monitor,
+                self.codex_terminal_monitor,
+            )
             snapshot = self.monitor.snapshot(include_stale=False)
         except Exception as exc:
             log_status_bar(f"refresh error: {exc}")
@@ -1054,8 +1100,19 @@ class StatusBarController(NSObject):
             latest_state_path=default_latest_state_path(),
         )
 
+    def build_codex_terminal_monitor(self) -> AgentMonitor:
+        return AgentMonitor(
+            sources=(
+                SourceSpec(
+                    CODEX_TRANSCRIPT_PROVIDER,
+                    Path.home() / ".codex" / "sessions",
+                ),
+            ),
+        )
+
     def reload_monitor(self) -> None:
         self.monitor = self.build_monitor()
+        self.codex_terminal_monitor = self.build_codex_terminal_monitor()
 
     def start_event_server(self) -> None:
         self.stop_event_server()

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -86,7 +86,7 @@ from sidepulse.lid_sleep import (
     run_sudo_pmset_disablesleep,
     sleep_helper_sudoers_rule,
 )
-from sidepulse.models import AgentMode, AgentStatus, AggregateStatus
+from sidepulse.models import AgentMode, AgentStatus, AggregateStatus, HookEvent
 from sidepulse.origin import ProcessInfo, origin_from_processes
 from sidepulse.providers import (
     detect_grok_config,
@@ -693,6 +693,124 @@ class AgentMonitorTests(unittest.TestCase):
             )
             self.assertEqual(reloaded.snapshot().aggregate.mode, AgentMode.TOOL_RUNNING)
             self.assertEqual(reloaded.snapshot().statuses[0].origin, "Codex UI")
+
+    def test_status_bar_startup_replay_ingests_recent_debug_logs(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            log = base / "codex.jsonl"
+            session_id = "eeeeeeee-ffff-7aaa-8bbb-cccccccccccc"
+            log.write_text(
+                json.dumps(
+                    {
+                        "logged_at": datetime.now(timezone.utc).isoformat(),
+                        "event": {
+                            "hook_event_name": "UserPromptSubmit",
+                            "session_id": session_id,
+                            "cwd": "/tmp/project",
+                            "prompt": "startup replay should restore this",
+                        },
+                    }
+                )
+                + "\n"
+            )
+            monitor = LiveAgentMonitor()
+
+            with patch(
+                "sidepulse.status_bar.detect_log_path",
+                return_value=log,
+            ):
+                replayed = status_bar.replay_recent_debug_logs(
+                    monitor,
+                    providers=("codex",),
+                    max_lines=20,
+                )
+
+            snapshot = monitor.snapshot()
+            self.assertEqual(replayed, 1)
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.WORKING)
+            self.assertIn("startup replay", snapshot.statuses[0].display_name)
+
+    def test_status_bar_reconciles_missing_codex_stop_hook_from_transcript(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        now = datetime.now(timezone.utc)
+        session_id = "eeeeeeee-ffff-7aaa-8bbb-cccccccccccc"
+        live = LiveAgentMonitor()
+        live.ingest_record(
+            HookEvent(
+                provider="codex",
+                logged_at=now,
+                event_name="UserPromptSubmit",
+                raw={"prompt": "try this after the limit"},
+                session_id=session_id,
+            )
+        )
+        transcript = AgentMonitor(sources=())
+        completed = AgentStatus(
+            provider="codex",
+            agent_id=f"codex:session:{session_id}",
+            display_name="Codex limit test",
+            mode=AgentMode.COMPLETED,
+            updated_at=now + timedelta(seconds=2),
+            event_name="Stop",
+            session_id=session_id,
+            message="You've hit your usage limit.",
+        )
+
+        with patch.object(transcript, "latest_statuses", return_value=(completed,)):
+            changed = status_bar.reconcile_codex_terminal_transcripts(live, transcript)
+
+        self.assertEqual(changed, 1)
+        snapshot = live.snapshot()
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
+        self.assertIn("usage limit", snapshot.statuses[0].message)
+
+    def test_status_bar_keeps_newer_live_codex_state_during_reconciliation(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        now = datetime.now(timezone.utc)
+        session_id = "dddddddd-eeee-7fff-8aaa-bbbbbbbbbbbb"
+        live = LiveAgentMonitor()
+        live.ingest_record(
+            HookEvent(
+                provider="codex",
+                logged_at=now,
+                event_name="UserPromptSubmit",
+                raw={"prompt": "a newer request"},
+                session_id=session_id,
+            )
+        )
+        transcript = AgentMonitor(sources=())
+        stale_completion = AgentStatus(
+            provider="codex",
+            agent_id=f"codex:session:{session_id}",
+            display_name="Codex stale completion",
+            mode=AgentMode.COMPLETED,
+            updated_at=now - timedelta(seconds=2),
+            event_name="Stop",
+            session_id=session_id,
+        )
+
+        with patch.object(
+            transcript,
+            "latest_statuses",
+            return_value=(stale_completion,),
+        ):
+            changed = status_bar.reconcile_codex_terminal_transcripts(live, transcript)
+
+        self.assertEqual(changed, 0)
+        self.assertEqual(live.snapshot().aggregate.mode, AgentMode.WORKING)
 
     def test_status_bar_session_menu_title_is_task_and_project(self) -> None:
         try:
@@ -6910,6 +7028,63 @@ class AgentMonitorTests(unittest.TestCase):
 
             self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
             self.assertEqual(snapshot.statuses[0].event_name, "Stop")
+
+    def test_codex_transcript_usage_limit_completes_without_stop_hook(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            session_id = "019ff788-2e54-7f12-8d13-91b66abe029d"
+            path = root / f"rollout-2026-08-12T15-52-04-{session_id}.jsonl"
+            now = datetime.now(timezone.utc).isoformat()
+            path.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "timestamp": now,
+                                "type": "turn_context",
+                                "payload": {"cwd": "/tmp/project", "turn_id": "turn-1"},
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "timestamp": now,
+                                "type": "response_item",
+                                "payload": {
+                                    "type": "message",
+                                    "role": "user",
+                                    "content": [{"type": "input_text", "text": "continue"}],
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "timestamp": now,
+                                "type": "event_msg",
+                                "payload": {
+                                    "type": "task_complete",
+                                    "turn_id": "turn-1",
+                                    "last_agent_message": None,
+                                    "error": {
+                                        "message": "You've hit your usage limit.",
+                                        "codex_error_info": "usage_limit_exceeded",
+                                    },
+                                },
+                            }
+                        ),
+                    ]
+                )
+                + "\n"
+            )
+
+            monitor = AgentMonitor(
+                sources=(SourceSpec("codex-transcripts", root),),
+                stale_after_seconds=3600,
+            )
+            snapshot = monitor.snapshot()
+
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
+            self.assertEqual(snapshot.statuses[0].event_name, "Stop")
+            self.assertIn("usage limit", snapshot.statuses[0].message)
 
     def test_claude_transcript_fallback_marks_tool_calls_running(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- reconcile terminal Codex transcript states into the live menu-bar monitor
- preserve newer live activity when an older transcript completion exists
- surface usage-limit errors when `last_agent_message` is absent

## Why

Codex can record `task_complete` after rejecting a request because usage is exhausted without emitting the live `Stop` hook SidePulse normally consumes. SidePulse could therefore remain in Working after the turn ended.

The reconciliation accepts only newer terminal transcript states, so stale completions cannot overwrite newer live requests.

Fixes #4.

## Review focus

- terminal transcript reconciliation runs only when the transcript state is newer
- usage-limit completion cannot overwrite newer live Working activity
- the change is limited to Codex state reconciliation and its regression coverage

This PR is independent of the other open provider and diagnostics PRs.

## Validation

- verified against a real Codex `usage_limit_exceeded` transcript
- regression coverage for missing stop hooks and newer-live-state preservation
- GitHub Actions passes on macOS with Python 3.10 and 3.12
