### PR TITLE
Add Antigravity hook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The monitor currently supports:
 | Codex | `~/.codex/config.toml` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/codex.jsonl` |
 | Claude | `~/.claude/settings.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/claude.jsonl` |
 | Grok | `~/.grok/hooks/sidepulse.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/grok.jsonl` |
+| Antigravity | `~/.gemini/config/hooks.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/antigravity.jsonl` |
 
 #### Local reply classifier (Apple Silicon)
 
@@ -271,11 +272,12 @@ Set up this Mac explicitly after package install:
 sidepulse setup
 ```
 
-`sidepulse setup` installs or refreshes Codex, Claude, and Grok hooks, installs
+`sidepulse setup` installs or refreshes Codex, Claude, Grok, and Antigravity hooks, installs
 SidePulse Pro Eject Prevention, writes the status-bar LaunchAgent, starts both helpers
 immediately, and enables them at login. This is intentionally an explicit
 command instead of a `pip install` side effect. To set up only one provider, use
-`sidepulse setup codex`, `sidepulse setup claude`, or `sidepulse setup grok`.
+`sidepulse setup codex`, `sidepulse setup claude`, `sidepulse setup grok`, or
+`sidepulse setup antigravity`.
 To skip the status-bar app but still install hooks and SidePulse Pro Eject Prevention, use
 `sidepulse setup --no-status-bar`.
 
@@ -332,6 +334,7 @@ sidepulse agent-monitor install
 sidepulse agent-monitor install codex
 sidepulse agent-monitor install claude
 sidepulse agent-monitor install grok
+sidepulse agent-monitor install antigravity
 ```
 
 Each hook invokes a small, standard-library-only Python entry point. It writes
@@ -433,6 +436,7 @@ sidepulse agent-monitor uninstall
 sidepulse agent-monitor uninstall codex
 sidepulse agent-monitor uninstall claude
 sidepulse agent-monitor uninstall grok
+sidepulse agent-monitor uninstall antigravity
 ```
 
 Install and start the macOS status-bar app:

--- a/src/sidepulse/antigravity_hook.py
+++ b/src/sidepulse/antigravity_hook.py
@@ -1,0 +1,95 @@
+"""Adapt Antigravity lifecycle hooks to SidePulse events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .hook import routed_hook_payload, write_hook_line, write_hook_status_audit
+from .ipc import send_hook_event
+
+
+EVENT_ALIASES = {
+    "PreInvocation": "UserPromptSubmit",
+    "PostInvocation": "PostToolUse",
+    "PreToolUse": "PreToolUse",
+    "PostToolUse": "PostToolUse",
+    "Stop": "Stop",
+}
+
+
+def normalize_payload(event_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized["hook_event_name"] = EVENT_ALIASES.get(event_name, event_name)
+    normalized["session_id"] = str(payload.get("conversationId") or "")
+    normalized["transcript_path"] = str(payload.get("transcriptPath") or "")
+    normalized["model"] = str(payload.get("modelName") or "")
+    normalized["agent_origin"] = "Antigravity"
+    normalized["agent_origin_kind"] = "antigravity_app"
+    normalized["agent_origin_source"] = "hook:antigravity"
+    normalized["agent_origin_confidence"] = "explicit"
+
+    workspace_paths = payload.get("workspacePaths")
+    if isinstance(workspace_paths, list) and workspace_paths:
+        normalized["cwd"] = str(workspace_paths[0])
+
+    tool_call = payload.get("toolCall")
+    if isinstance(tool_call, dict):
+        normalized["tool_name"] = str(tool_call.get("name") or "")
+        normalized["tool_input"] = tool_call.get("args")
+
+    error = payload.get("error")
+    if isinstance(error, str) and error:
+        normalized["message"] = error
+        normalized["tool_response"] = {"error": error}
+
+    if event_name == "Stop" and not payload.get("fullyIdle", True):
+        normalized["hook_event_name"] = "PostToolUse"
+        normalized["message"] = "Background work is still running"
+
+    return normalized
+
+
+def response_for_event(event_name: str) -> dict[str, Any]:
+    if event_name == "PreToolUse":
+        return {"decision": "allow"}
+    if event_name == "PreInvocation":
+        return {"injectSteps": []}
+    if event_name == "PostInvocation":
+        return {"injectSteps": [], "terminationBehavior": ""}
+    if event_name == "Stop":
+        return {"decision": ""}
+    return {}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--log", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        raw = json.loads(sys.stdin.read() or "{}")
+        payload = raw if isinstance(raw, dict) else {}
+        normalized = normalize_payload(args.event, payload)
+        provider, log_path, line = routed_hook_payload(
+            "antigravity",
+            args.log.expanduser(),
+            json.dumps(normalized, separators=(",", ":"), ensure_ascii=False),
+        )
+        send_hook_event(provider, line)
+        write_hook_line(log_path, line)
+        write_hook_status_audit(provider, line)
+    except Exception:
+        pass
+
+    sys.stdout.write(json.dumps(response_for_event(args.event), separators=(",", ":")))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sidepulse/cli.py
+++ b/src/sidepulse/cli.py
@@ -20,10 +20,12 @@ from .collector import AgentMonitor, SourceSpec, default_sources
 from .device_writer import DEFAULT_FILE_NAME, DeviceWriteError, write_led_program
 from .hook import hook_log_main
 from .install import (
+    install_antigravity_hooks,
     install_claude_hooks,
     install_codex_hooks,
     install_cursor_hooks,
     install_grok_hooks,
+    uninstall_antigravity_hooks,
     uninstall_claude_hooks,
     uninstall_codex_hooks,
     uninstall_cursor_hooks,
@@ -42,6 +44,7 @@ from .providers import (
     detect_claude_config,
     detect_codex_config,
     detect_grok_config,
+    detect_antigravity_config,
     detect_log_path,
     default_log_path,
 )
@@ -99,6 +102,7 @@ def build_sidepulse_parser() -> argparse.ArgumentParser:
     setup.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     setup.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     setup.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    setup.add_argument("--antigravity-log", type=Path, help="Antigravity JSONL log path.")
     setup.add_argument("--dry-run", action="store_true", help="Show what would change.")
     setup.add_argument(
         "--sd-eject-guard-scope",
@@ -642,20 +646,22 @@ def build_parser(prog: str = "agent-monitor") -> argparse.ArgumentParser:
     )
     status_bar.set_defaults(func=cmd_status_bar)
 
-    install = subparsers.add_parser("install", help="Install Codex, Claude, and/or Grok monitor hooks.")
+    install = subparsers.add_parser("install", help="Install supported agent monitor hooks.")
     install.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
     install.add_argument("--log-dir", type=Path, help="Directory for provider JSONL files.")
     install.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     install.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     install.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    install.add_argument("--antigravity-log", type=Path, help="Antigravity JSONL log path.")
     install.add_argument("--dry-run", action="store_true", help="Show what would change.")
     install.set_defaults(func=cmd_install)
 
-    uninstall = subparsers.add_parser("uninstall", help="Remove Codex, Claude, and/or Grok monitor hooks.")
+    uninstall = subparsers.add_parser("uninstall", help="Remove supported agent monitor hooks.")
     uninstall.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
     uninstall.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     uninstall.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     uninstall.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    uninstall.add_argument("--antigravity-log", type=Path, help="Antigravity JSONL log path.")
     uninstall.add_argument("--dry-run", action="store_true", help="Show what would change.")
     uninstall.set_defaults(func=cmd_uninstall)
 
@@ -697,10 +703,16 @@ def add_status_args(parser: argparse.ArgumentParser, include_json: bool = True) 
     parser.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     parser.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     parser.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    parser.add_argument("--antigravity-log", type=Path, help="Antigravity JSONL log path.")
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
-    configs = [detect_codex_config(), detect_claude_config(), detect_grok_config()]
+    configs = [
+        detect_codex_config(),
+        detect_claude_config(),
+        detect_grok_config(),
+        detect_antigravity_config(),
+    ]
     payload = {"providers": [config.to_dict() for config in configs]}
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -821,8 +833,10 @@ def install_hook_results(args: argparse.Namespace):
             results.append(install_claude_hooks(log_path=log_path, dry_run=args.dry_run))
         elif provider == "cursor":
             results.append(install_cursor_hooks(log_path=log_path, dry_run=args.dry_run))
-        else:
+        elif provider == "grok":
             results.append(install_grok_hooks(log_path=log_path, dry_run=args.dry_run))
+        else:
+            results.append(install_antigravity_hooks(log_path=log_path, dry_run=args.dry_run))
     return results
 
 
@@ -849,8 +863,10 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
             results.append(uninstall_claude_hooks(log_path=log_path, dry_run=args.dry_run))
         elif provider == "cursor":
             results.append(uninstall_cursor_hooks(log_path=log_path, dry_run=args.dry_run))
-        else:
+        elif provider == "grok":
             results.append(uninstall_grok_hooks(log_path=log_path, dry_run=args.dry_run))
+        else:
+            results.append(uninstall_antigravity_hooks(log_path=log_path, dry_run=args.dry_run))
 
     for result in results:
         action = "would remove" if args.dry_run and result.changed else "removed"

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -485,6 +485,7 @@ def default_sources(settings: AgentMonitorSettings | None = None) -> tuple[Sourc
     if active_settings.claude_transcripts_enabled:
         sources.append(SourceSpec(CLAUDE_TRANSCRIPT_PROVIDER, Path.home() / ".claude" / "projects"))
     sources.append(SourceSpec("grok", detect_log_path("grok")))
+    sources.append(SourceSpec("antigravity", detect_log_path("antigravity")))
     return unique_sources(sources)
 
 

--- a/src/sidepulse/hook.py
+++ b/src/sidepulse/hook.py
@@ -106,10 +106,15 @@ def hook_event_socket_disabled() -> bool:
 
 
 def hook_log_main(provider: str, log_path: Path, event: str | None = None) -> int:
+    response_text = None
     try:
         payload_text = sys.stdin.read()
-        if provider == "cursor" and event:
-            from .cursor_hook import normalize_payload
+        if provider in {"cursor", "antigravity"} and event:
+            if provider == "cursor":
+                from .cursor_hook import normalize_payload
+            else:
+                from .antigravity_hook import normalize_payload, response_for_event
+                response_text = json.dumps(response_for_event(event), separators=(",", ":"))
 
             try:
                 raw = json.loads(payload_text or "{}")
@@ -129,5 +134,13 @@ def hook_log_main(provider: str, log_path: Path, event: str | None = None) -> in
         write_hook_line(actual_log_path, line)
         write_hook_status_audit(actual_provider, line)
     except Exception:
+        if provider == "antigravity" and event and response_text is None:
+            from .antigravity_hook import response_for_event
+
+            response_text = json.dumps(response_for_event(event), separators=(",", ":"))
+        if response_text is not None:
+            sys.stdout.write(response_text + "\n")
         return 0
+    if response_text is not None:
+        sys.stdout.write(response_text + "\n")
     return 0

--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -16,10 +16,12 @@ from pathlib import Path
 from typing import Any
 
 from .providers import (
+    ANTIGRAVITY_EVENTS,
     CLAUDE_EVENTS,
     CODEX_EVENTS,
     CURSOR_EVENTS,
     GROK_EVENTS,
+    default_antigravity_hook_config_path,
     default_cursor_hook_config_path,
     default_grok_hook_config_path,
     detect_log_path,
@@ -167,6 +169,38 @@ def install_grok_hooks(
         target_log.touch(exist_ok=True)
 
     return InstallResult("grok", config, target_log, changed, backup, dry_run)
+
+
+def install_antigravity_hooks(
+    log_path: Path | None = None,
+    config_path: Path | None = None,
+    dry_run: bool = False,
+    python_executable: str | None = None,
+) -> InstallResult:
+    config = config_path or default_antigravity_hook_config_path()
+    target_log = (log_path or detect_log_path("antigravity")).expanduser()
+    data = read_json_config(config)
+    original = json.dumps(data, sort_keys=True)
+    integration: dict[str, Any] = {}
+    for event_name in ANTIGRAVITY_EVENTS:
+        integration[event_name] = [
+            antigravity_hook_entry(
+                event_name,
+                antigravity_hook_command(event_name, target_log, python_executable),
+            )
+        ]
+    data["sidepulse-agent-monitor"] = integration
+
+    changed = json.dumps(data, sort_keys=True) != original
+    backup = None
+    if changed and not dry_run:
+        config.parent.mkdir(parents=True, exist_ok=True)
+        backup = backup_file(config)
+        config.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n")
+        target_log.parent.mkdir(parents=True, exist_ok=True)
+        target_log.touch(exist_ok=True)
+
+    return InstallResult("antigravity", config, target_log, changed, backup, dry_run)
 
 
 def uninstall_codex_hooks(
@@ -418,6 +452,28 @@ def remove_cursor_hook_entries(entries: list[Any]) -> list[Any]:
     ]
 
 
+def uninstall_antigravity_hooks(
+    log_path: Path | None = None,
+    config_path: Path | None = None,
+    dry_run: bool = False,
+) -> InstallResult:
+    config = config_path or default_antigravity_hook_config_path()
+    target_log = (log_path or detect_log_path("antigravity")).expanduser()
+    data = read_json_config(config)
+    original = json.dumps(data, sort_keys=True)
+    data.pop("sidepulse-agent-monitor", None)
+    changed = json.dumps(data, sort_keys=True) != original
+    backup = None
+    if changed and not dry_run:
+        config.parent.mkdir(parents=True, exist_ok=True)
+        backup = backup_file(config)
+        if data:
+            config.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n")
+        else:
+            config.unlink(missing_ok=True)
+    return InstallResult("antigravity", config, target_log, changed, backup, dry_run)
+
+
 def hook_command(
     provider: str,
     log_path: Path,
@@ -565,6 +621,54 @@ def grok_hook_entry(event_name: str, command: str) -> dict[str, Any]:
     if event_name in {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionDenied", "Notification"}:
         entry["matcher"] = "*"
     return entry
+
+
+def antigravity_hook_command(
+    event_name: str,
+    log_path: Path,
+    python_executable: str | None = None,
+) -> str:
+    executable = python_executable or sys.executable or "python3"
+    if getattr(sys, "frozen", False) and python_executable is None:
+        command = " ".join(
+            [
+                shlex.quote(executable),
+                "agent-monitor",
+                "hook-log",
+                "--provider",
+                "antigravity",
+                "--event",
+                shlex.quote(event_name),
+                "--log",
+                shlex.quote(str(log_path.expanduser())),
+            ]
+        )
+        return fail_open_command(command)
+    entry_point = Path(__file__).with_name("hook_entry.py")
+    command = " ".join(
+        [
+            shlex.quote(executable),
+            shlex.quote(str(entry_point)),
+            "--provider",
+            "antigravity",
+            "--event",
+            shlex.quote(event_name),
+            "--log",
+            shlex.quote(str(log_path.expanduser())),
+        ]
+    )
+    return fail_open_command(command)
+
+
+def antigravity_hook_entry(event_name: str, command: str) -> dict[str, Any]:
+    hook: dict[str, Any] = {
+        "type": "command",
+        "command": command,
+        "timeout": 5,
+    }
+    if event_name in {"PreToolUse", "PostToolUse"}:
+        return {"matcher": "*", "hooks": [hook]}
+    return hook
 
 
 def hook_pythonpath_assignment() -> str:

--- a/src/sidepulse/models.py
+++ b/src/sidepulse/models.py
@@ -160,4 +160,5 @@ def provider_label(provider: str) -> str:
         "grok": "Grok",
         # Lowercase is the product's own spelling, and provider.title() would break it.
         "opencode": "opencode",
+        "antigravity": "Antigravity",
     }.get(provider, provider.title())

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -74,7 +74,15 @@ CURSOR_EVENTS = (
     "stop",
 )
 
-HOOK_PROVIDERS = ("codex", "claude", "grok", "cursor")
+ANTIGRAVITY_EVENTS = (
+    "PreInvocation",
+    "PostInvocation",
+    "PreToolUse",
+    "PostToolUse",
+    "Stop",
+)
+
+HOOK_PROVIDERS = ("codex", "claude", "grok", "cursor", "antigravity")
 KNOWN_EVENTS = tuple(dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS))
 
 
@@ -134,6 +142,7 @@ def detect_provider_configs(home: Path | None = None) -> list[ProviderConfig]:
         detect_claude_config(home),
         detect_grok_config(home),
         detect_cursor_config(home),
+        detect_antigravity_config(home),
     ]
 
 
@@ -335,6 +344,37 @@ def _paths_from_cursor_entries(entries: list[Any]) -> list[Path]:
     return paths
 
 
+def default_antigravity_hook_config_path(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".gemini" / "config" / "hooks.json"
+
+
+def detect_antigravity_config(home: Path | None = None) -> ProviderConfig:
+    config_path = default_antigravity_hook_config_path(home)
+    if not config_path.exists():
+        return ProviderConfig("antigravity", config_path, False, False, (), ())
+    try:
+        data = json.loads(config_path.read_text())
+    except Exception:
+        return ProviderConfig("antigravity", config_path, True, False, (), ())
+    integration = data.get("sidepulse-agent-monitor") or {}
+    hook_events: list[str] = []
+    paths: list[Path] = []
+    if isinstance(integration, dict):
+        for event_name, entries in integration.items():
+            if event_name not in ANTIGRAVITY_EVENTS or not isinstance(entries, list):
+                continue
+            hook_events.append(event_name)
+            paths.extend(_paths_from_hook_entries(entries))
+    return ProviderConfig(
+        "antigravity",
+        config_path,
+        True,
+        bool(hook_events),
+        tuple(sorted(set(hook_events))),
+        _dedupe_paths(paths),
+    )
+
+
 def detect_log_path(provider: str, home: Path | None = None) -> Path:
     if provider == "codex":
         config = detect_codex_config(home)
@@ -344,6 +384,8 @@ def detect_log_path(provider: str, home: Path | None = None) -> Path:
         config = detect_grok_config(home)
     elif provider == "cursor":
         config = detect_cursor_config(home)
+    elif provider == "antigravity":
+        config = detect_antigravity_config(home)
     else:
         config = ProviderConfig(provider, default_log_path(provider, home), False, False, (), ())
     if config.log_paths:
@@ -488,6 +530,18 @@ def _paths_from_hook_entries(entries: list[Any]) -> list[Path]:
             command = hook.get("command")
             if isinstance(command, str):
                 paths.extend(extract_log_paths_from_command(command))
+    return paths
+
+
+def _paths_from_antigravity_entries(entries: list[Any]) -> list[Path]:
+    paths: list[Path] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        command = entry.get("command")
+        if isinstance(command, str):
+            paths.extend(extract_log_paths_from_command(command))
+        paths.extend(_paths_from_hook_entries([entry]))
     return paths
 
 

--- a/tests/test_antigravity_provider.py
+++ b/tests/test_antigravity_provider.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sidepulse.antigravity_hook import normalize_payload, response_for_event
+from sidepulse.install import install_antigravity_hooks, uninstall_antigravity_hooks
+from sidepulse.models import AgentMode
+from sidepulse.collector import AgentMonitor, SourceSpec
+from sidepulse.providers import detect_antigravity_config
+
+
+class AntigravityProviderTests(unittest.TestCase):
+    def test_installer_preserves_other_integrations_and_is_detectable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            config = home / ".gemini" / "config" / "hooks.json"
+            config.parent.mkdir(parents=True)
+            config.write_text(json.dumps({"other-integration": {"enabled": True}}))
+            log = home / "state" / "antigravity.jsonl"
+
+            result = install_antigravity_hooks(
+                config_path=config,
+                log_path=log,
+                python_executable="python3",
+            )
+
+            self.assertTrue(result.changed)
+            data = json.loads(config.read_text())
+            self.assertIn("other-integration", data)
+            self.assertEqual(
+                set(data["sidepulse-agent-monitor"]),
+                {"PreInvocation", "PostInvocation", "PreToolUse", "PostToolUse", "Stop"},
+            )
+            detected = detect_antigravity_config(home)
+            self.assertTrue(detected.hooks_enabled)
+            self.assertEqual(detected.log_paths, (log,))
+            command = data["sidepulse-agent-monitor"]["Stop"][0]["command"]
+            self.assertIn("hook_entry.py", command)
+            self.assertIn("--provider antigravity", command)
+            self.assertIn("--event Stop", command)
+
+    def test_uninstaller_removes_only_sidepulse_integration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / "hooks.json"
+            log = root / "antigravity.jsonl"
+            config.write_text(
+                json.dumps(
+                    {
+                        "other-integration": {"enabled": True},
+                        "sidepulse-agent-monitor": {"Stop": []},
+                    }
+                )
+            )
+
+            uninstall_antigravity_hooks(config_path=config, log_path=log)
+
+            self.assertEqual(
+                json.loads(config.read_text()),
+                {"other-integration": {"enabled": True}},
+            )
+
+    def test_quota_error_stop_completes_the_session(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            log = root / "antigravity.jsonl"
+            normalized = normalize_payload(
+                "Stop",
+                {
+                    "conversationId": "conversation-1",
+                    "fullyIdle": True,
+                    "terminationReason": "ERROR",
+                    "error": "RESOURCE_EXHAUSTED: Individual quota reached",
+                    "workspacePaths": ["/tmp/project"],
+                },
+            )
+            normalized["logged_at"] = datetime.now(timezone.utc).isoformat()
+            log.write_text(json.dumps(normalized) + "\n")
+
+            snapshot = AgentMonitor(
+                sources=(SourceSpec("antigravity", log),),
+                stale_after_seconds=10**9,
+            ).snapshot()
+
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
+            self.assertIn("quota reached", snapshot.statuses[0].message)
+
+    def test_background_stop_remains_working(self) -> None:
+        normalized = normalize_payload(
+            "Stop",
+            {"conversationId": "conversation-1", "fullyIdle": False},
+        )
+        self.assertEqual(normalized["hook_event_name"], "PostToolUse")
+
+    def test_hook_responses_preserve_antigravity_contract(self) -> None:
+        self.assertEqual(response_for_event("PreToolUse"), {"decision": "allow"})
+        self.assertEqual(response_for_event("PreInvocation"), {"injectSteps": []})
+        self.assertEqual(response_for_event("Stop"), {"decision": ""})
+
+    def test_shared_hook_entry_writes_antigravity_protocol_response(self) -> None:
+        import io
+        import os
+        import sys
+        from contextlib import redirect_stdout
+        from unittest.mock import patch
+
+        from sidepulse.hook import hook_log_main
+
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "antigravity.jsonl"
+            buffer = io.StringIO()
+            with (
+                patch.dict(os.environ, {"SIDEPULSE_DISABLE_EVENT_SOCKET": "1"}),
+                patch.object(sys, "stdin", io.StringIO('{"conversationId":"c1"}')),
+                redirect_stdout(buffer),
+            ):
+                code = hook_log_main("antigravity", log, event="PreToolUse")
+
+            self.assertEqual(code, 0)
+            self.assertEqual(json.loads(buffer.getvalue().strip()), {"decision": "allow"})
+            self.assertTrue(log.exists())
+            self.assertIn("PreToolUse", log.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -3608,6 +3608,13 @@ class AgentMonitorTests(unittest.TestCase):
             changed=True,
             backup_path=None,
         )
+        antigravity_result = SimpleNamespace(
+            provider="antigravity",
+            config_path=Path("/tmp/antigravity-hooks.json"),
+            log_path=Path("/tmp/antigravity.jsonl"),
+            changed=True,
+            backup_path=None,
+        )
         launch_result = SimpleNamespace(
             plist_path=Path("/tmp/io.sidepulse.agentstatus.plist"),
             changed=True,
@@ -3633,6 +3640,11 @@ class AgentMonitorTests(unittest.TestCase):
                 return_value=cursor_result,
             ) as cursor,
             patch.object(cli_module, "install_grok_hooks", return_value=grok_result) as grok,
+            patch.object(
+                cli_module,
+                "install_antigravity_hooks",
+                return_value=antigravity_result,
+            ) as antigravity,
             patch(
                 "sidepulse.sd_eject_guard_launch.install_sd_eject_guard",
                 return_value=guard_result,
@@ -3649,6 +3661,7 @@ class AgentMonitorTests(unittest.TestCase):
         claude.assert_called_once()
         cursor.assert_called_once()
         grok.assert_called_once()
+        antigravity.assert_called_once()
         guard.assert_called_once_with(scope="auto", dry_run=False)
         launch.assert_called_once_with(start=True)
 


### PR DESCRIPTION
## Summary

- add Antigravity as a first-class SidePulse hook provider
- install and remove a named integration in `~/.gemini/config/hooks.json` without disturbing unrelated entries
- normalize invocation, tool, stop, background-work, and quota-error payloads
- expose Antigravity through setup, doctor, monitoring sources, and CLI commands

## Why

Antigravity uses provider-specific camelCase payloads and expects event-specific JSON responses on stdout. The adapter preserves that contract while feeding SidePulse's provider-neutral state model.

## Review focus

- `sidepulse-agent-monitor` is the only managed key in the Gemini hooks file
- unrelated integrations survive install and uninstall unchanged
- hook responses remain valid for Antigravity while monitoring failures stay fail-open

This PR is independent of the other open provider PRs.

## Validation

- exercised with real Antigravity events, including `RESOURCE_EXHAUSTED` and `fullyIdle=false`
- installer coverage verifies unrelated hook integrations are preserved
- GitHub Actions passes on macOS with Python 3.10 and 3.12
