### PR TITLE
Add Cursor hook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The monitor currently supports:
 | Codex | `~/.codex/config.toml` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/codex.jsonl` |
 | Claude | `~/.claude/settings.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/claude.jsonl` |
 | Grok | `~/.grok/hooks/sidepulse.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/grok.jsonl` |
+| Cursor | `~/.cursor/hooks.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/cursor.jsonl` |
 
 #### Local reply classifier (Apple Silicon)
 
@@ -211,11 +212,12 @@ Set up this Mac explicitly after package install:
 sidepulse setup
 ```
 
-`sidepulse setup` installs or refreshes Codex, Claude, and Grok hooks, installs
+`sidepulse setup` installs or refreshes Codex, Claude, Grok, and Cursor hooks, installs
 SidePulse Pro Eject Prevention, writes the status-bar LaunchAgent, starts both helpers
 immediately, and enables them at login. This is intentionally an explicit
 command instead of a `pip install` side effect. To set up only one provider, use
-`sidepulse setup codex`, `sidepulse setup claude`, or `sidepulse setup grok`.
+`sidepulse setup codex`, `sidepulse setup claude`, `sidepulse setup grok`, or
+`sidepulse setup cursor`.
 To skip the status-bar app but still install hooks and SidePulse Pro Eject Prevention, use
 `sidepulse setup --no-status-bar`.
 
@@ -272,6 +274,7 @@ sidepulse agent-monitor install
 sidepulse agent-monitor install codex
 sidepulse agent-monitor install claude
 sidepulse agent-monitor install grok
+sidepulse agent-monitor install cursor
 ```
 
 Each hook invokes a small, standard-library-only Python entry point. It writes
@@ -373,6 +376,7 @@ sidepulse agent-monitor uninstall
 sidepulse agent-monitor uninstall codex
 sidepulse agent-monitor uninstall claude
 sidepulse agent-monitor uninstall grok
+sidepulse agent-monitor uninstall cursor
 ```
 
 Install and start the macOS status-bar app:

--- a/src/sidepulse/cli.py
+++ b/src/sidepulse/cli.py
@@ -22,9 +22,11 @@ from .hook import hook_log_main
 from .install import (
     install_claude_hooks,
     install_codex_hooks,
+    install_cursor_hooks,
     install_grok_hooks,
     uninstall_claude_hooks,
     uninstall_codex_hooks,
+    uninstall_cursor_hooks,
     uninstall_grok_hooks,
 )
 from .led_status import AgentLedController, LedStatusWrite
@@ -39,6 +41,7 @@ from .providers import (
     HOOK_PROVIDERS,
     detect_claude_config,
     detect_codex_config,
+    detect_cursor_config,
     detect_grok_config,
     detect_log_path,
     default_log_path,
@@ -96,6 +99,7 @@ def build_sidepulse_parser() -> argparse.ArgumentParser:
     setup.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     setup.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     setup.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    setup.add_argument("--cursor-log", type=Path, help="Cursor JSONL log path.")
     setup.add_argument("--dry-run", action="store_true", help="Show what would change.")
     setup.add_argument(
         "--sd-eject-guard-scope",
@@ -625,20 +629,22 @@ def build_parser(prog: str = "agent-monitor") -> argparse.ArgumentParser:
     )
     status_bar.set_defaults(func=cmd_status_bar)
 
-    install = subparsers.add_parser("install", help="Install Codex, Claude, and/or Grok monitor hooks.")
+    install = subparsers.add_parser("install", help="Install supported agent monitor hooks.")
     install.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
     install.add_argument("--log-dir", type=Path, help="Directory for provider JSONL files.")
     install.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     install.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     install.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    install.add_argument("--cursor-log", type=Path, help="Cursor JSONL log path.")
     install.add_argument("--dry-run", action="store_true", help="Show what would change.")
     install.set_defaults(func=cmd_install)
 
-    uninstall = subparsers.add_parser("uninstall", help="Remove Codex, Claude, and/or Grok monitor hooks.")
+    uninstall = subparsers.add_parser("uninstall", help="Remove supported agent monitor hooks.")
     uninstall.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
     uninstall.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     uninstall.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     uninstall.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    uninstall.add_argument("--cursor-log", type=Path, help="Cursor JSONL log path.")
     uninstall.add_argument("--dry-run", action="store_true", help="Show what would change.")
     uninstall.set_defaults(func=cmd_uninstall)
 
@@ -683,10 +689,16 @@ def add_status_args(parser: argparse.ArgumentParser, include_json: bool = True) 
     parser.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     parser.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     parser.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    parser.add_argument("--cursor-log", type=Path, help="Cursor JSONL log path.")
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
-    configs = [detect_codex_config(), detect_claude_config(), detect_grok_config()]
+    configs = [
+        detect_codex_config(),
+        detect_claude_config(),
+        detect_grok_config(),
+        detect_cursor_config(),
+    ]
     payload = {"providers": [config.to_dict() for config in configs]}
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -805,8 +817,10 @@ def install_hook_results(args: argparse.Namespace):
             results.append(install_codex_hooks(log_path=log_path, dry_run=args.dry_run))
         elif provider == "claude":
             results.append(install_claude_hooks(log_path=log_path, dry_run=args.dry_run))
-        else:
+        elif provider == "grok":
             results.append(install_grok_hooks(log_path=log_path, dry_run=args.dry_run))
+        else:
+            results.append(install_cursor_hooks(log_path=log_path, dry_run=args.dry_run))
     return results
 
 
@@ -831,8 +845,10 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
             results.append(uninstall_codex_hooks(log_path=log_path, dry_run=args.dry_run))
         elif provider == "claude":
             results.append(uninstall_claude_hooks(log_path=log_path, dry_run=args.dry_run))
-        else:
+        elif provider == "grok":
             results.append(uninstall_grok_hooks(log_path=log_path, dry_run=args.dry_run))
+        else:
+            results.append(uninstall_cursor_hooks(log_path=log_path, dry_run=args.dry_run))
 
     for result in results:
         action = "would remove" if args.dry_run and result.changed else "removed"

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -485,6 +485,7 @@ def default_sources(settings: AgentMonitorSettings | None = None) -> tuple[Sourc
     if active_settings.claude_transcripts_enabled:
         sources.append(SourceSpec(CLAUDE_TRANSCRIPT_PROVIDER, Path.home() / ".claude" / "projects"))
     sources.append(SourceSpec("grok", detect_log_path("grok")))
+    sources.append(SourceSpec("cursor", detect_log_path("cursor")))
     return unique_sources(sources)
 
 

--- a/src/sidepulse/cursor_hook.py
+++ b/src/sidepulse/cursor_hook.py
@@ -1,0 +1,90 @@
+"""Adapt Cursor lifecycle hooks to SidePulse events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .hook import routed_hook_payload, write_hook_line, write_hook_status_audit
+from .ipc import send_hook_event
+
+
+EVENT_ALIASES = {
+    "sessionStart": "SessionStart",
+    "beforeSubmitPrompt": "UserPromptSubmit",
+    "beforeShellExecution": "PreToolUse",
+    "afterShellExecution": "PostToolUse",
+    "afterFileEdit": "PostToolUse",
+    "postToolUse": "PostToolUse",
+    "stop": "Stop",
+}
+
+
+def normalize_payload(event_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized["hook_event_name"] = EVENT_ALIASES.get(event_name, event_name)
+    normalized["session_id"] = str(
+        payload.get("conversation_id") or payload.get("conversationId") or ""
+    )
+    normalized["agent_origin"] = "Cursor"
+    normalized["agent_origin_kind"] = "cursor_app"
+    normalized["agent_origin_source"] = "hook:cursor"
+    normalized["agent_origin_confidence"] = "explicit"
+
+    workspace_roots = payload.get("workspace_roots") or payload.get("workspaceRoots")
+    if isinstance(workspace_roots, list) and workspace_roots:
+        normalized["cwd"] = str(workspace_roots[0])
+    elif payload.get("workspace_root"):
+        normalized["cwd"] = str(payload["workspace_root"])
+
+    prompt = payload.get("prompt")
+    if isinstance(prompt, str):
+        normalized["prompt"] = prompt
+
+    if event_name == "beforeShellExecution":
+        normalized["tool_name"] = "shell"
+        normalized["tool_input"] = {"command": payload.get("command")}
+    elif event_name in {"afterShellExecution", "afterFileEdit", "postToolUse"}:
+        normalized["tool_name"] = str(payload.get("tool_name") or event_name)
+        normalized["tool_response"] = {
+            "status": payload.get("status"),
+            "exit_code": payload.get("exit_code"),
+        }
+
+    status = payload.get("status")
+    if event_name == "stop" and isinstance(status, str):
+        normalized["message"] = f"Cursor stopped: {status}"
+
+    return normalized
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--log", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        raw = json.loads(sys.stdin.read() or "{}")
+        payload = raw if isinstance(raw, dict) else {}
+        normalized = normalize_payload(args.event, payload)
+        provider, log_path, line = routed_hook_payload(
+            "cursor",
+            args.log.expanduser(),
+            json.dumps(normalized, separators=(",", ":"), ensure_ascii=False),
+        )
+        send_hook_event(provider, line)
+        write_hook_line(log_path, line)
+        write_hook_status_audit(provider, line)
+    except Exception:
+        pass
+
+    sys.stdout.write("{}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sidepulse/cursor_hook.py
+++ b/src/sidepulse/cursor_hook.py
@@ -14,11 +14,14 @@ from .ipc import send_hook_event
 
 EVENT_ALIASES = {
     "sessionStart": "SessionStart",
+    "sessionEnd": "SessionEnd",
     "beforeSubmitPrompt": "UserPromptSubmit",
+    "preToolUse": "PreToolUse",
     "beforeShellExecution": "PreToolUse",
     "afterShellExecution": "PostToolUse",
     "afterFileEdit": "PostToolUse",
     "postToolUse": "PostToolUse",
+    "postToolUseFailure": "StopFailure",
     "stop": "Stop",
 }
 
@@ -44,15 +47,26 @@ def normalize_payload(event_name: str, payload: dict[str, Any]) -> dict[str, Any
     if isinstance(prompt, str):
         normalized["prompt"] = prompt
 
-    if event_name == "beforeShellExecution":
-        normalized["tool_name"] = "shell"
-        normalized["tool_input"] = {"command": payload.get("command")}
-    elif event_name in {"afterShellExecution", "afterFileEdit", "postToolUse"}:
+    if event_name in {"beforeShellExecution", "preToolUse"}:
+        normalized["tool_name"] = str(payload.get("tool_name") or "shell")
+        normalized["tool_input"] = payload.get("tool_input") or {
+            "command": payload.get("command")
+        }
+    elif event_name in {
+        "afterShellExecution",
+        "afterFileEdit",
+        "postToolUse",
+        "postToolUseFailure",
+    }:
         normalized["tool_name"] = str(payload.get("tool_name") or event_name)
         normalized["tool_response"] = {
             "status": payload.get("status"),
             "exit_code": payload.get("exit_code"),
+            "error": payload.get("error_message"),
         }
+
+    if event_name == "postToolUseFailure" and payload.get("error_message"):
+        normalized["message"] = str(payload["error_message"])
 
     status = payload.get("status")
     if event_name == "stop" and isinstance(status, str):

--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -18,8 +18,10 @@ from typing import Any
 from .providers import (
     CLAUDE_EVENTS,
     CODEX_EVENTS,
+    CURSOR_EVENTS,
     GROK_EVENTS,
     default_grok_hook_config_path,
+    default_cursor_hook_config_path,
     detect_log_path,
 )
 
@@ -160,6 +162,47 @@ def install_grok_hooks(
     return InstallResult("grok", config, target_log, changed, backup, dry_run)
 
 
+def install_cursor_hooks(
+    log_path: Path | None = None,
+    config_path: Path | None = None,
+    dry_run: bool = False,
+    python_executable: str | None = None,
+) -> InstallResult:
+    config = config_path or default_cursor_hook_config_path()
+    target_log = (log_path or detect_log_path("cursor")).expanduser()
+    data = read_json_config(config)
+    original = json.dumps(data, sort_keys=True)
+    data.setdefault("version", 1)
+    hooks = data.setdefault("hooks", {})
+
+    for event_name in CURSOR_EVENTS:
+        entries = hooks.get(event_name, [])
+        if not isinstance(entries, list):
+            entries = []
+        cleaned = remove_cursor_hook_entries(entries)
+        cleaned.append(
+            {
+                "command": cursor_hook_command(
+                    event_name,
+                    target_log,
+                    python_executable,
+                )
+            }
+        )
+        hooks[event_name] = cleaned
+
+    changed = json.dumps(data, sort_keys=True) != original
+    backup = None
+    if changed and not dry_run:
+        config.parent.mkdir(parents=True, exist_ok=True)
+        backup = backup_file(config)
+        config.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n")
+        target_log.parent.mkdir(parents=True, exist_ok=True)
+        target_log.touch(exist_ok=True)
+
+    return InstallResult("cursor", config, target_log, changed, backup, dry_run)
+
+
 def uninstall_codex_hooks(
     log_path: Path | None = None,
     config_path: Path | None = None,
@@ -265,6 +308,39 @@ def uninstall_grok_hooks(
     return InstallResult("grok", config, target_log, changed, backup, dry_run)
 
 
+def uninstall_cursor_hooks(
+    log_path: Path | None = None,
+    config_path: Path | None = None,
+    dry_run: bool = False,
+) -> InstallResult:
+    config = config_path or default_cursor_hook_config_path()
+    target_log = (log_path or detect_log_path("cursor")).expanduser()
+    data = read_json_config(config)
+    original = json.dumps(data, sort_keys=True)
+    hooks = data.get("hooks")
+    if isinstance(hooks, dict):
+        for event_name in list(hooks):
+            entries = hooks.get(event_name)
+            if not isinstance(entries, list):
+                continue
+            cleaned = remove_cursor_hook_entries(entries)
+            if cleaned:
+                hooks[event_name] = cleaned
+            else:
+                hooks.pop(event_name, None)
+        if not hooks:
+            data.pop("hooks", None)
+
+    changed = json.dumps(data, sort_keys=True) != original
+    backup = None
+    if changed and not dry_run:
+        config.parent.mkdir(parents=True, exist_ok=True)
+        backup = backup_file(config)
+        config.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n")
+
+    return InstallResult("cursor", config, target_log, changed, backup, dry_run)
+
+
 def hook_command(
     provider: str,
     log_path: Path,
@@ -309,6 +385,34 @@ def grok_hook_entry(event_name: str, command: str) -> dict[str, Any]:
     if event_name in {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionDenied", "Notification"}:
         entry["matcher"] = "*"
     return entry
+
+
+def cursor_hook_command(
+    event_name: str,
+    log_path: Path,
+    python_executable: str | None = None,
+) -> str:
+    executable = python_executable or sys.executable or "python3"
+    return " ".join(
+        [
+            shlex.quote(executable),
+            "-m",
+            "sidepulse.cursor_hook",
+            "--event",
+            shlex.quote(event_name),
+            "--log",
+            shlex.quote(str(log_path.expanduser())),
+        ]
+    )
+
+
+def remove_cursor_hook_entries(entries: list[Any]) -> list[dict[str, Any]]:
+    return [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and "sidepulse.cursor_hook" not in str(entry.get("command") or "")
+    ]
 
 
 def hook_pythonpath_assignment() -> str:

--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -524,12 +524,14 @@ def cursor_hook_command(
     )
 
 
-def remove_cursor_hook_entries(entries: list[Any]) -> list[dict[str, Any]]:
+def remove_cursor_hook_entries(entries: list[Any]) -> list[Any]:
     return [
         entry
         for entry in entries
-        if isinstance(entry, dict)
-        and "sidepulse.cursor_hook" not in str(entry.get("command") or "")
+        if not (
+            isinstance(entry, dict)
+            and "sidepulse.cursor_hook" in str(entry.get("command") or "")
+        )
     ]
 
 

--- a/src/sidepulse/models.py
+++ b/src/sidepulse/models.py
@@ -158,4 +158,5 @@ def provider_label(provider: str) -> str:
         "codex": "Codex",
         "claude": "Claude",
         "grok": "Grok",
+        "cursor": "Cursor",
     }.get(provider, provider.title())

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -63,11 +63,14 @@ GROK_EVENTS = (
 
 CURSOR_EVENTS = (
     "sessionStart",
+    "sessionEnd",
     "beforeSubmitPrompt",
+    "preToolUse",
     "beforeShellExecution",
     "afterShellExecution",
     "afterFileEdit",
     "postToolUse",
+    "postToolUseFailure",
     "stop",
 )
 

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -61,7 +61,17 @@ GROK_EVENTS = (
     "SessionEnd",
 )
 
-HOOK_PROVIDERS = ("codex", "claude", "grok")
+CURSOR_EVENTS = (
+    "sessionStart",
+    "beforeSubmitPrompt",
+    "beforeShellExecution",
+    "afterShellExecution",
+    "afterFileEdit",
+    "postToolUse",
+    "stop",
+)
+
+HOOK_PROVIDERS = ("codex", "claude", "grok", "cursor")
 KNOWN_EVENTS = tuple(dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS))
 
 
@@ -101,7 +111,12 @@ def default_log_path(provider: str, home: Path | None = None) -> Path:
 
 
 def detect_provider_configs(home: Path | None = None) -> list[ProviderConfig]:
-    return [detect_codex_config(home), detect_claude_config(home), detect_grok_config(home)]
+    return [
+        detect_codex_config(home),
+        detect_claude_config(home),
+        detect_grok_config(home),
+        detect_cursor_config(home),
+    ]
 
 
 def detect_codex_config(home: Path | None = None) -> ProviderConfig:
@@ -243,6 +258,48 @@ def detect_grok_config(home: Path | None = None) -> ProviderConfig:
     )
 
 
+def default_cursor_hook_config_path(home: Path | None = None) -> Path:
+    base = home or Path.home()
+    return base / ".cursor" / "hooks.json"
+
+
+def detect_cursor_config(home: Path | None = None) -> ProviderConfig:
+    config_path = default_cursor_hook_config_path(home)
+    if not config_path.exists():
+        return ProviderConfig("cursor", config_path, False, False, (), ())
+
+    try:
+        data = json.loads(config_path.read_text())
+    except Exception:
+        return ProviderConfig("cursor", config_path, True, False, (), ())
+
+    hooks = data.get("hooks") or {}
+    hook_events: list[str] = []
+    paths: list[Path] = []
+    if isinstance(hooks, dict):
+        for event_name, entries in hooks.items():
+            if event_name not in CURSOR_EVENTS or not isinstance(entries, list):
+                continue
+            managed_entries = [
+                entry
+                for entry in entries
+                if isinstance(entry, dict)
+                and "sidepulse.cursor_hook" in str(entry.get("command") or "")
+            ]
+            if managed_entries:
+                hook_events.append(event_name)
+                paths.extend(_paths_from_cursor_entries(managed_entries))
+
+    return ProviderConfig(
+        "cursor",
+        config_path,
+        True,
+        bool(hook_events),
+        tuple(sorted(set(hook_events))),
+        _dedupe_paths(paths),
+    )
+
+
 def detect_log_path(provider: str, home: Path | None = None) -> Path:
     if provider == "codex":
         config = detect_codex_config(home)
@@ -250,6 +307,8 @@ def detect_log_path(provider: str, home: Path | None = None) -> Path:
         config = detect_claude_config(home)
     elif provider == "grok":
         config = detect_grok_config(home)
+    elif provider == "cursor":
+        config = detect_cursor_config(home)
     else:
         config = ProviderConfig(provider, default_log_path(provider, home), False, False, (), ())
     if config.log_paths:
@@ -394,6 +453,17 @@ def _paths_from_hook_entries(entries: list[Any]) -> list[Path]:
             command = hook.get("command")
             if isinstance(command, str):
                 paths.extend(extract_log_paths_from_command(command))
+    return paths
+
+
+def _paths_from_cursor_entries(entries: list[Any]) -> list[Path]:
+    paths: list[Path] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        command = entry.get("command")
+        if isinstance(command, str):
+            paths.extend(extract_log_paths_from_command(command))
     return paths
 
 

--- a/tests/test_cursor_provider.py
+++ b/tests/test_cursor_provider.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sidepulse.collector import AgentMonitor, SourceSpec
+from sidepulse.cursor_hook import normalize_payload
+from sidepulse.install import install_cursor_hooks, uninstall_cursor_hooks
+from sidepulse.models import AgentMode
+from sidepulse.providers import detect_cursor_config
+
+
+class CursorProviderTests(unittest.TestCase):
+    def test_installer_preserves_existing_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            config = home / ".cursor" / "hooks.json"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "hooks": {"stop": [{"command": "python notify.py"}]},
+                    }
+                )
+            )
+            log = home / "state" / "cursor.jsonl"
+
+            install_cursor_hooks(
+                config_path=config,
+                log_path=log,
+                python_executable="python3",
+            )
+
+            data = json.loads(config.read_text())
+            stop_commands = [entry["command"] for entry in data["hooks"]["stop"]]
+            self.assertIn("python notify.py", stop_commands)
+            self.assertTrue(any("sidepulse.cursor_hook" in item for item in stop_commands))
+            detected = detect_cursor_config(home)
+            self.assertTrue(detected.hooks_enabled)
+            self.assertEqual(detected.log_paths, (log,))
+
+    def test_uninstaller_removes_only_sidepulse_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / "hooks.json"
+            log = root / "cursor.jsonl"
+            config.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "hooks": {"stop": [{"command": "python notify.py"}]},
+                    }
+                )
+            )
+            install_cursor_hooks(config_path=config, log_path=log)
+
+            uninstall_cursor_hooks(config_path=config, log_path=log)
+
+            data = json.loads(config.read_text())
+            self.assertEqual(data["hooks"]["stop"], [{"command": "python notify.py"}])
+            self.assertFalse(
+                any(
+                    "sidepulse.cursor_hook" in str(entry.get("command") or "")
+                    for entries in data["hooks"].values()
+                    for entry in entries
+                )
+            )
+
+    def test_prompt_and_stop_map_to_working_then_completed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "cursor.jsonl"
+            now = datetime.now(timezone.utc).isoformat()
+            prompt = normalize_payload(
+                "beforeSubmitPrompt",
+                {
+                    "conversation_id": "cursor-conversation",
+                    "workspace_roots": ["/tmp/project"],
+                    "prompt": "fix the test",
+                },
+            )
+            prompt["logged_at"] = now
+            stopped = normalize_payload(
+                "stop",
+                {"conversation_id": "cursor-conversation", "status": "completed"},
+            )
+            stopped["logged_at"] = now
+            log.write_text(json.dumps(prompt) + "\n" + json.dumps(stopped) + "\n")
+
+            snapshot = AgentMonitor(
+                sources=(SourceSpec("cursor", log),),
+                stale_after_seconds=3600,
+            ).snapshot()
+
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
+            self.assertEqual(snapshot.statuses[0].origin, "Cursor")
+
+    def test_shell_hook_maps_to_tool_activity(self) -> None:
+        normalized = normalize_payload(
+            "beforeShellExecution",
+            {"conversation_id": "cursor-conversation", "command": "pytest"},
+        )
+        self.assertEqual(normalized["hook_event_name"], "PreToolUse")
+        self.assertEqual(normalized["tool_name"], "shell")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cursor_provider.py
+++ b/tests/test_cursor_provider.py
@@ -70,6 +70,19 @@ class CursorProviderTests(unittest.TestCase):
                 )
             )
 
+    def test_installer_preserves_unknown_hook_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / "hooks.json"
+            log = root / "cursor.jsonl"
+            config.write_text(
+                json.dumps({"version": 1, "hooks": {"stop": ["future-hook"]}})
+            )
+
+            install_cursor_hooks(config_path=config, log_path=log)
+
+            self.assertIn("future-hook", json.loads(config.read_text())["hooks"]["stop"])
+
     def test_prompt_and_stop_map_to_working_then_completed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "cursor.jsonl"
@@ -105,6 +118,29 @@ class CursorProviderTests(unittest.TestCase):
         )
         self.assertEqual(normalized["hook_event_name"], "PreToolUse")
         self.assertEqual(normalized["tool_name"], "shell")
+
+    def test_generic_tool_hooks_map_to_activity_and_failure(self) -> None:
+        before = normalize_payload(
+            "preToolUse",
+            {
+                "conversation_id": "cursor-conversation",
+                "tool_name": "read_file",
+                "tool_input": {"path": "README.md"},
+            },
+        )
+        failed = normalize_payload(
+            "postToolUseFailure",
+            {
+                "conversation_id": "cursor-conversation",
+                "tool_name": "read_file",
+                "error_message": "permission denied",
+            },
+        )
+
+        self.assertEqual(before["hook_event_name"], "PreToolUse")
+        self.assertEqual(before["tool_name"], "read_file")
+        self.assertEqual(failed["hook_event_name"], "StopFailure")
+        self.assertEqual(failed["message"], "permission denied")
 
 
 if __name__ == "__main__":

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -1760,6 +1760,13 @@ class AgentMonitorTests(unittest.TestCase):
             changed=True,
             backup_path=None,
         )
+        cursor_result = SimpleNamespace(
+            provider="cursor",
+            config_path=Path("/tmp/cursor-hooks.json"),
+            log_path=Path("/tmp/cursor.jsonl"),
+            changed=True,
+            backup_path=None,
+        )
         launch_result = SimpleNamespace(
             plist_path=Path("/tmp/io.sidepulse.agentstatus.plist"),
             changed=True,
@@ -1780,6 +1787,11 @@ class AgentMonitorTests(unittest.TestCase):
             patch.object(cli_module, "install_codex_hooks", return_value=codex_result) as codex,
             patch.object(cli_module, "install_claude_hooks", return_value=claude_result) as claude,
             patch.object(cli_module, "install_grok_hooks", return_value=grok_result) as grok,
+            patch.object(
+                cli_module,
+                "install_cursor_hooks",
+                return_value=cursor_result,
+            ) as cursor,
             patch(
                 "sidepulse.sd_eject_guard_launch.install_sd_eject_guard",
                 return_value=guard_result,
@@ -1795,6 +1807,7 @@ class AgentMonitorTests(unittest.TestCase):
         codex.assert_called_once()
         claude.assert_called_once()
         grok.assert_called_once()
+        cursor.assert_called_once()
         guard.assert_called_once_with(scope="auto", dry_run=False)
         launch.assert_called_once_with(start=True)
 


### PR DESCRIPTION
## Summary

- add Cursor IDE/CLI lifecycle hooks as a SidePulse provider
- merge managed hooks into `~/.cursor/hooks.json` while preserving existing hooks
- normalize prompt, shell, file-edit, tool, and stop events into SidePulse states
- expose Cursor through setup, agent-monitor commands, doctor output, and default sources

## Why

Cursor supports global and project-level JSON hooks. SidePulse can use the global lifecycle hooks to represent both IDE and CLI agent activity without scraping Cursor's internal state.

The adapter always returns valid JSON and does not block or alter Cursor's agent loop.

Cursor hook reference: https://cursor.com/blog/agent-best-practices

## Validation

- `PYTHONPATH=src python -m unittest discover -s tests -v`
- 168 tests passed
- tests cover preserving third-party hooks, clean uninstall, lifecycle mapping, and shell activity
