### PR TITLE
Add isolated user installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ Install locally for the `sidepulse` CLI:
 python3 -m pip install -e .
 ```
 
+For an isolated user installation that does not modify system Python packages:
+
+```sh
+./scripts/install-user.sh
+~/.local/bin/sidepulse setup
+```
+
+The installer creates `~/.local/share/sidepulse/venv` and links the CLI into
+`~/.local/bin`. Override `PYTHON_BIN`, `SIDEPULSE_INSTALL_ROOT`, or
+`SIDEPULSE_BIN_DIR` when a different location is needed.
+
 This also installs the Cocoa dependencies for the macOS status-bar app.
 
 Set up this Mac explicitly after package install:

--- a/scripts/install-user.sh
+++ b/scripts/install-user.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+PYTHON_BIN=${PYTHON_BIN:-python3}
+INSTALL_ROOT=${SIDEPULSE_INSTALL_ROOT:-"$HOME/.local/share/sidepulse"}
+BIN_DIR=${SIDEPULSE_BIN_DIR:-"$HOME/.local/bin"}
+SOURCE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+VENV_DIR="$INSTALL_ROOT/venv"
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+"$VENV_DIR/bin/python" -m pip install --upgrade pip
+"$VENV_DIR/bin/python" -m pip install "$SOURCE_DIR"
+
+mkdir -p "$BIN_DIR"
+ln -sf "$VENV_DIR/bin/sidepulse" "$BIN_DIR/sidepulse"
+ln -sf "$VENV_DIR/bin/agent-monitor" "$BIN_DIR/agent-monitor"
+
+printf '%s\n' "SidePulse installed in $VENV_DIR"
+printf '%s\n' "CLI linked at $BIN_DIR/sidepulse"
+printf '%s\n' "Run: $BIN_DIR/sidepulse setup"

--- a/tests/test_install_user.py
+++ b/tests/test_install_user.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class UserInstallerTests(unittest.TestCase):
+    def test_installer_uses_isolated_venv_and_user_bin(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        script = root / "scripts" / "install-user.sh"
+        text = script.read_text()
+        self.assertIn('"$PYTHON_BIN" -m venv "$VENV_DIR"', text)
+        self.assertIn('"$VENV_DIR/bin/python" -m pip install', text)
+        self.assertNotIn("--break-system-packages", text)
+
+    def test_installer_shell_syntax(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(
+            ["sh", "-n", str(root / "scripts" / "install-user.sh")],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a user-level installer that creates a dedicated SidePulse virtual environment
- link the SidePulse CLIs into `~/.local/bin`
- document location overrides and the follow-up setup command

## Why

Installing directly into Homebrew or system Python can require `--break-system-packages` and can conflict with unrelated Python tooling. The installer keeps SidePulse and its Cocoa dependencies isolated while retaining a normal command-line entry point.

Fixes #2.

## Validation

- `PYTHONPATH=src python -m unittest discover -s tests -v`
- 166 tests passed
- shell syntax and isolation behavior covered by tests
