### PR TITLE
Add status-only Cursor provider (install cursor / publish-status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,29 @@ sidepulse agent-monitor install
 sidepulse agent-monitor install codex
 sidepulse agent-monitor install claude
 sidepulse agent-monitor install grok
+sidepulse agent-monitor install cursor
 ```
 
 Each hook invokes a small, standard-library-only Python entry point. It writes
 the event to the monitor log and then makes a short best-effort local socket
 delivery to the status-bar app.
+
+The `cursor` provider is different: it is **status-only**. Codex, Claude, and
+Grok hooks write agent session content (prompts, assistant messages, tool
+inputs) to the local monitor log. The Cursor integration deliberately does not.
+`sidepulse agent-monitor install cursor` writes `~/.cursor/hooks.json` so
+Cursor's `beforeSubmitPrompt` and `stop` events invoke `sidepulse
+agent-monitor publish-status working|done`, which publishes an explicit status
+transition over the status-bar socket and never stores message content — there
+is nothing to clear in more than one place.
+
+```sh
+sidepulse agent-monitor install cursor
+sidepulse agent-monitor uninstall cursor
+# Publish a status transition directly (no message content is stored):
+sidepulse agent-monitor publish-status working
+sidepulse agent-monitor publish-status done
+```
 
 Show current aggregated status:
 
@@ -384,6 +402,7 @@ sidepulse agent-monitor uninstall
 sidepulse agent-monitor uninstall codex
 sidepulse agent-monitor uninstall claude
 sidepulse agent-monitor uninstall grok
+sidepulse agent-monitor uninstall cursor
 ```
 
 Install and start the macOS status-bar app:

--- a/src/sidepulse/cli.py
+++ b/src/sidepulse/cli.py
@@ -17,12 +17,15 @@ from .battery import (
     render_battery_snapshot,
 )
 from .collector import AgentMonitor, SourceSpec, default_sources
+from .cursor_status import publish_status
 from .device_writer import DEFAULT_FILE_NAME, DeviceWriteError, write_led_program
 from .hook import hook_log_main
 from .install import (
+    install_cursor_hooks,
     install_claude_hooks,
     install_codex_hooks,
     install_grok_hooks,
+    uninstall_cursor_hooks,
     uninstall_claude_hooks,
     uninstall_codex_hooks,
     uninstall_grok_hooks,
@@ -658,6 +661,20 @@ def build_parser(prog: str = "agent-monitor") -> argparse.ArgumentParser:
 
     add_hook_log_parser(subparsers)
 
+    publish = subparsers.add_parser(
+        "publish-status",
+        help="Publish a status-only transition to the status-bar (no message content stored).",
+    )
+    publish.add_argument(
+        "status",
+        choices=("working", "done", "ask", "blocked", "idle"),
+        help="Status token to publish.",
+    )
+    publish.add_argument("--provider", default="cursor", help="Agent provider key (default: cursor).")
+    publish.add_argument("--session-id", default=None, help="Session id for the status row.")
+    publish.add_argument("--cwd", default=None, help="Working directory for the status row.")
+    publish.set_defaults(func=cmd_publish_status)
+
     return parser
 
 
@@ -697,7 +714,7 @@ def add_status_args(parser: argparse.ArgumentParser, include_json: bool = True) 
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
-    configs = [detect_codex_config(), detect_claude_config(), detect_grok_config()]
+    configs = detect_provider_configs()
     payload = {"providers": [config.to_dict() for config in configs]}
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -811,6 +828,9 @@ def install_hook_results(args: argparse.Namespace):
     providers = selected_hook_providers(args.provider)
     results = []
     for provider in providers:
+        if provider == "cursor":
+            results.append(install_cursor_hooks(dry_run=args.dry_run))
+            continue
         log_path = install_log_path(provider, args)
         if provider == "codex":
             results.append(install_codex_hooks(log_path=log_path, dry_run=args.dry_run))
@@ -837,6 +857,9 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
     providers = selected_hook_providers(args.provider)
     results = []
     for provider in providers:
+        if provider == "cursor":
+            results.append(uninstall_cursor_hooks(dry_run=args.dry_run))
+            continue
         log_path = uninstall_log_path(provider, args)
         if provider == "codex":
             results.append(uninstall_codex_hooks(log_path=log_path, dry_run=args.dry_run))
@@ -859,6 +882,16 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
 
 def cmd_hook_log(args: argparse.Namespace) -> int:
     return hook_log_main(args.provider, args.log)
+
+
+def cmd_publish_status(args: argparse.Namespace) -> int:
+    publish_status(
+        args.status,
+        provider=args.provider,
+        session_id=args.session_id,
+        cwd=args.cwd,
+    )
+    return 0
 
 
 def monitor_from_args(args: argparse.Namespace) -> AgentMonitor:

--- a/src/sidepulse/cursor_status.py
+++ b/src/sidepulse/cursor_status.py
@@ -1,0 +1,45 @@
+"""Status-only agent-status publishing, when a chat log is not wanted.
+
+SidePulse's codex/claude/grok hook integrations write agent session content
+(prompts, assistant messages, tool inputs) to local JSONL decision logs. The
+Cursor integration deliberately does **not**: it publishes only a status
+transition (``working`` / ``done`` / ``ask`` / ``blocked`` / ``idle``) to the
+status-bar unix socket. Nothing is written to disk and no message content
+ever crosses the wire, so there is nothing to clear in more than one place.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+from .ipc import send_hook_event
+
+VALID_STATUS = ("working", "done", "ask", "blocked", "idle")
+
+
+def publish_status(
+    status: str,
+    *,
+    provider: str = "cursor",
+    session_id: Optional[str] = None,
+    cwd: Optional[str] = None,
+) -> bool:
+    """Publish a status-only transition to the status-bar socket.
+
+    The event carries an explicit ``sidepulse_status`` token and no message
+    text, so the status bar can derive the aggregate mode without storing any
+    chat content. Returns ``True`` when the status bar accepted the event,
+    ``False`` when it is not running or the status token is invalid.
+    """
+    if status not in VALID_STATUS:
+        return False
+    line = {
+        "logged_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hook_event_name": "Notification",
+        "session_id": session_id or provider,
+        "cwd": cwd or os.getcwd(),
+        "sidepulse_status": status,
+    }
+    return send_hook_event(provider, line)

--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -18,8 +18,11 @@ from typing import Any
 from .providers import (
     CLAUDE_EVENTS,
     CODEX_EVENTS,
+    CURSOR_EVENTS,
     GROK_EVENTS,
+    default_cursor_hook_config_path,
     default_grok_hook_config_path,
+    default_log_path,
     detect_log_path,
 )
 
@@ -278,6 +281,118 @@ def uninstall_grok_hooks(
         clean_grok_live_backup_hook_files(config)
 
     return InstallResult("grok", config, target_log, changed, backup, dry_run)
+
+
+_CURSOR_EVENT_STATUS = {
+    "beforeSubmitPrompt": "working",
+    "stop": "done",
+}
+
+
+def cursor_status_command(status: str) -> str:
+    """Build a portable command that publishes a status-only transition.
+
+    Prefers the installed ``sidepulse`` / ``agent-monitor`` console script so
+    the hook keeps working regardless of how SidePulse was installed, and
+    falls back to ``python -m sidepulse``. The command is written into the
+    user's `~/.cursor/hooks.json` at install time.
+    """
+    status_q = shlex.quote(status)
+    bin_path = shutil.which("sidepulse") or shutil.which("agent-monitor")
+    if bin_path:
+        base = shlex.quote(bin_path)
+        if Path(bin_path).name == "agent-monitor":
+            return f"{base} publish-status {status_q}"
+        return f"{base} agent-monitor publish-status {status_q}"
+    return f"{shlex.quote(sys.executable)} -m sidepulse agent-monitor publish-status {status_q}"
+
+
+def _is_managed_cursor_entry(entry: Any) -> bool:
+    """True for a Cursor hook entry that this installer manages."""
+    return isinstance(entry, dict) and "publish-status" in str(entry.get("command", ""))
+
+
+def install_cursor_hooks(
+    config_path: Path | None = None,
+    *,
+    dry_run: bool = False,
+) -> InstallResult:
+    """Register status-only Cursor hooks in ~/.cursor/hooks.json.
+
+    Unlike the Codex / Claude / Grok hooks, nothing is logged: the Cursor
+    commands publish an explicit status transition over the status-bar socket
+    and carry no message content.
+    """
+    config = config_path or default_cursor_hook_config_path()
+    target_log = default_log_path("cursor")
+    data = read_json_config(config)
+    original = json.dumps(data if isinstance(data, dict) else {}, sort_keys=True)
+    if not isinstance(data, dict):
+        data = {}
+    data.setdefault("version", 1)
+    hooks = data.setdefault("hooks", {})
+
+    for event_name, status in _CURSOR_EVENT_STATUS.items():
+        entries = hooks.get(event_name)
+        if not isinstance(entries, list):
+            entries = hooks[event_name] = []
+        cleaned = [entry for entry in entries if not _is_managed_cursor_entry(entry)]
+        cleaned.append({"command": cursor_status_command(status)})
+        hooks[event_name] = cleaned
+
+    changed = json.dumps(data, sort_keys=True) != original
+    backup = None
+    if changed and not dry_run:
+        config.parent.mkdir(parents=True, exist_ok=True)
+        backup = backup_file(config)
+        config.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n")
+        target_log.parent.mkdir(parents=True, exist_ok=True)
+
+    return InstallResult("cursor", config, target_log, changed, backup, dry_run)
+
+
+def uninstall_cursor_hooks(
+    config_path: Path | None = None,
+    *,
+    dry_run: bool = False,
+) -> InstallResult:
+    """Remove the managed Cursor status hooks, preserving any other hooks."""
+    config = config_path or default_cursor_hook_config_path()
+    target_log = default_log_path("cursor")
+    data = read_json_config(config)
+    if not isinstance(data, dict) or not data:
+        return InstallResult("cursor", config, target_log, False, None, dry_run)
+
+    original = json.dumps(data, sort_keys=True)
+    hooks = data.get("hooks")
+    if isinstance(hooks, dict):
+        for event_name in list(hooks):
+            if event_name not in CURSOR_EVENTS:
+                continue
+            entries = hooks.get(event_name)
+            if not isinstance(entries, list):
+                continue
+            cleaned = [entry for entry in entries if not _is_managed_cursor_entry(entry)]
+            if cleaned:
+                hooks[event_name] = cleaned
+            else:
+                hooks.pop(event_name, None)
+        if not hooks:
+            data.pop("hooks", None)
+
+    changed = json.dumps(data, sort_keys=True) != original
+    backup = None
+    if changed and not dry_run:
+        backup = backup_file(config)
+        if data:
+            config.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n")
+        else:
+            try:
+                config.unlink()
+            except FileNotFoundError:
+                pass
+
+    return InstallResult("cursor", config, target_log, changed, backup, dry_run)
 
 
 def hook_command(

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -61,7 +61,16 @@ GROK_EVENTS = (
     "SessionEnd",
 )
 
-HOOK_PROVIDERS = ("codex", "claude", "grok")
+# Cursor's hook events that SidePulse subscribes to. Unlike the Codex / Claude
+# / Grok hooks, the Cursor integration is status-only: the registered commands
+# publish an explicit `sidepulse_status` transition and never write message
+# content to a local log.
+CURSOR_EVENTS = (
+    "beforeSubmitPrompt",
+    "stop",
+)
+
+HOOK_PROVIDERS = ("codex", "claude", "grok", "cursor")
 KNOWN_EVENTS = tuple(dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS))
 
 
@@ -101,7 +110,48 @@ def default_log_path(provider: str, home: Path | None = None) -> Path:
 
 
 def detect_provider_configs(home: Path | None = None) -> list[ProviderConfig]:
-    return [detect_codex_config(home), detect_claude_config(home), detect_grok_config(home)]
+    return [
+        detect_codex_config(home),
+        detect_claude_config(home),
+        detect_grok_config(home),
+        detect_cursor_config(home),
+    ]
+
+
+def default_cursor_hook_config_path(home: Path | None = None) -> Path:
+    base = home or Path.home()
+    return base / ".cursor" / "hooks.json"
+
+
+def detect_cursor_config(home: Path | None = None) -> ProviderConfig:
+    config_path = default_cursor_hook_config_path(home)
+    if not config_path.exists():
+        return ProviderConfig("cursor", config_path, False, False, (), ())
+
+    try:
+        data = json.loads(config_path.read_text())
+    except Exception:
+        return ProviderConfig("cursor", config_path, True, False, (), ())
+
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    events: list[str] = []
+    if isinstance(hooks, dict):
+        for event_name, entries in hooks.items():
+            if event_name not in CURSOR_EVENTS or not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if isinstance(entry, dict) and "publish-status" in str(entry.get("command", "")):
+                    events.append(event_name)
+                    break
+
+    return ProviderConfig(
+        "cursor",
+        config_path,
+        True,
+        bool(events),
+        tuple(sorted(set(events))),
+        (),
+    )
 
 
 def detect_codex_config(home: Path | None = None) -> ProviderConfig:

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -40,6 +40,7 @@ from sidepulse.collector import (
     default_sources,
 )
 from sidepulse.cli import build_parser, visible_watch_statuses
+from sidepulse.cursor_status import VALID_STATUS, publish_status
 from sidepulse.device_writer import (
     DeviceWriteError,
     discover_devices,
@@ -51,9 +52,11 @@ from sidepulse.hook import format_hook_payload, routed_hook_payload, write_hook_
 from sidepulse.ipc import HookEventServer, send_hook_event
 from sidepulse.install import (
     hook_command,
+    install_cursor_hooks,
     install_claude_hooks,
     install_codex_hooks,
     install_grok_hooks,
+    uninstall_cursor_hooks,
     uninstall_claude_hooks,
     uninstall_codex_hooks,
     uninstall_grok_hooks,
@@ -84,6 +87,7 @@ from sidepulse.lid_sleep import (
 from sidepulse.models import AgentMode, AgentStatus, AggregateStatus
 from sidepulse.origin import ProcessInfo, origin_from_processes
 from sidepulse.providers import (
+    detect_cursor_config,
     detect_grok_config,
     default_log_path,
     default_state_dir,
@@ -3066,6 +3070,124 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertTrue(detected.hooks_enabled)
             self.assertIn("PreToolUse", detected.hook_events)
             self.assertIn(log, detected.log_paths)
+
+    def test_cursor_installer_writes_status_only_hooks_and_preserves_other_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "sidepulse.install.shutil.which", return_value="/usr/local/bin/sidepulse"
+        ):
+            base = Path(tmp)
+            config = base / ".cursor" / "hooks.json"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "hooks": {
+                            "afterFileEdit": [
+                                {"command": "bun run .cursor/hooks/grind.ts"}
+                            ]
+                        },
+                    }
+                )
+            )
+
+            result = install_cursor_hooks(config_path=config)
+
+            self.assertTrue(result.changed)
+            data = json.loads(config.read_text())
+            self.assertEqual(data["version"], 1)
+            # User's own hook is preserved.
+            self.assertEqual(
+                data["hooks"]["afterFileEdit"],
+                [{"command": "bun run .cursor/hooks/grind.ts"}],
+            )
+            # Our status-only hooks point at publish-status and carry no content.
+            self.assertEqual(
+                data["hooks"]["beforeSubmitPrompt"],
+                [{"command": "/usr/local/bin/sidepulse agent-monitor publish-status working"}],
+            )
+            self.assertEqual(
+                data["hooks"]["stop"],
+                [{"command": "/usr/local/bin/sidepulse agent-monitor publish-status done"}],
+            )
+
+    def test_cursor_uninstaller_removes_managed_hooks_and_preserves_other_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "sidepulse.install.shutil.which", return_value="/usr/local/bin/sidepulse"
+        ):
+            base = Path(tmp)
+            config = base / ".cursor" / "hooks.json"
+            config.parent.mkdir(parents=True)
+            install_cursor_hooks(config_path=config)
+            data = json.loads(config.read_text())
+            data["hooks"]["afterFileEdit"] = [{"command": "bun run grind.ts"}]
+            config.write_text(json.dumps(data))
+
+            result = uninstall_cursor_hooks(config_path=config)
+
+            self.assertTrue(result.changed)
+            data = json.loads(config.read_text())
+            self.assertNotIn("beforeSubmitPrompt", data["hooks"])
+            self.assertNotIn("stop", data["hooks"])
+            # Unrelated hooks survive.
+            self.assertEqual(data["hooks"]["afterFileEdit"], [{"command": "bun run grind.ts"}])
+
+    def test_detect_cursor_config_reads_managed_hook_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "sidepulse.install.shutil.which", return_value="/usr/local/bin/sidepulse"
+        ):
+            home = Path(tmp)
+            config = home / ".cursor" / "hooks.json"
+            config.parent.mkdir(parents=True)
+            install_cursor_hooks(config_path=config)
+
+            detected = detect_cursor_config(home)
+
+            self.assertEqual(detected.provider, "cursor")
+            self.assertTrue(detected.exists)
+            self.assertTrue(detected.hooks_enabled)
+            self.assertIn("beforeSubmitPrompt", detected.hook_events)
+            self.assertIn("stop", detected.hook_events)
+
+    def test_cursor_publish_status_reaches_status_bar_socket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ, {"XDG_STATE_HOME": tmp}, clear=False
+        ):
+            received: list[tuple[str, dict]] = []
+            server = HookEventServer(lambda provider, line: received.append((provider, line)))
+            server.start()
+            try:
+                ok = publish_status("working", cwd="/workspace")
+            finally:
+                time.sleep(0.2)
+                server.stop()
+
+            self.assertTrue(ok)
+            self.assertEqual(len(received), 1)
+            provider, line = received[0]
+            self.assertEqual(provider, "cursor")
+            self.assertEqual(line["sidepulse_status"], "working")
+            self.assertEqual(line["cwd"], "/workspace")
+
+    def test_cursor_publish_status_is_status_only_and_validates(self) -> None:
+        self.assertIn("working", VALID_STATUS)
+        with patch("sidepulse.cursor_status.send_hook_event", return_value=True) as send:
+            ok = publish_status("working", provider="cursor", cwd="/workspace")
+            self.assertTrue(ok)
+            self.assertEqual(send.call_count, 1)
+            provider, state = send.call_args.args
+            self.assertEqual(provider, "cursor")
+            self.assertEqual(state["sidepulse_status"], "working")
+            # No message content is ever included.
+            self.assertNotIn("message", state)
+            self.assertNotIn("prompt", state)
+            self.assertNotIn("last_assistant_message", state)
+
+    def test_cursor_publish_status_rejects_invalid_token(self) -> None:
+        with patch("sidepulse.cursor_status.send_hook_event", return_value=True) as send:
+            ok = publish_status("not-a-status")
+            self.assertFalse(ok)
+            send.assert_not_called()
 
     def test_sidepulse_sidepulse_command_shape(self) -> None:
         parser = build_parser(prog="sidepulse agent-monitor")


### PR DESCRIPTION
## What

Adds **Cursor** as a fourth agent provider alongside `codex` / `claude` / `grok`, with a deliberate privacy difference: the Cursor integration is **status-only**.

### Why status-only
The Codex/Claude/Grok hooks write agent session content (prompts, assistant messages, tool inputs) to a local JSONL decision log. The Cursor integration does **not**. `install cursor` writes `~/.cursor/hooks.json` so Cursor's `beforeSubmitPrompt` and `stop` events invoke `sidepulse agent-monitor publish-status working|done`, which publishes an explicit status transition over the status-bar socket and **stores no message content**. There is nothing to clear in more than one place.

## Changes
- `providers`: `CURSOR_EVENTS`, `default_cursor_hook_config_path`, `detect_cursor_config`; `doctor` now uses `detect_provider_configs()` so it reports every provider (it previously hardcoded the three).
- `install`: `install_cursor_hooks` / `uninstall_cursor_hooks` — writes/removes the managed entries in `~/.cursor/hooks.json`, backs up the file, and preserves any unrelated user hooks.
- `cli`: new `publish-status` subcommand (`working|done|ask|blocked|idle`), wired into `install`/`uninstall`/`setup` (`install cursor`).
- New `cursor_status.publish_status()` — status-only socket emit.
- Tests: installer/uninstaller/detection, status-only invariant (no `message`/`prompt` in the emitted event), invalid-token rejection, and a live socket round-trip through `HookEventServer`.
- README documents the `cursor` provider and its status-only behavior.

## Verification
- `173 passed` (`pytest tests/`).
- Scratch-HOME smoke: `agent-monitor install cursor` writes hooks.json, `uninstall cursor` cleans up and preserves unrelated hooks, `doctor` reports cursor.
- Live socket round-trip confirmed (published event → `HookEventServer` + status-bar → `latest.json` `mode: working` / `completed`, `message: null`).

## Notes
- Cursor hook events are `beforeSubmitPrompt` (→ working) and `stop` (→ done). No Ask/Blocked state from Cursor yet — out of scope here, and it never writes message content regardless.
- The registered hook command resolves the `sidepulse` CLI via `shutil.which` at install time, so it works for pip, `-e`, and uv-tool installs (no hardcoded paths).