### PR TITLE
feat: add Hermes Agent lifecycle integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ SidePulse Pro and SidePulse Dot.
 
 #### AI Agent Monitoring
 
-SidePulse can monitor AI agents such as Codex, Claude, and Grok through hooks, then
+SidePulse can monitor AI agents such as Codex, Claude, Grok, and Hermes through hooks, then
 translate the current agent state into a small, glanceable LED status.
 
 Agent status modes:
@@ -147,6 +147,10 @@ The monitor currently supports:
 | Codex | `~/.codex/config.toml` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/codex.jsonl` |
 | Claude | `~/.claude/settings.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/claude.jsonl` |
 | Grok | `~/.grok/hooks/sidepulse.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/grok.jsonl` |
+| Hermes | [Hermes lifecycle plugin](integrations/hermes/) | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/hermes.jsonl` |
+
+Hermes uses a native, privacy-safe lifecycle plugin instead of shell hooks. Install
+and diagnose it using the instructions in [`integrations/hermes`](integrations/hermes/).
 
 #### Local reply classifier (Apple Silicon)
 
@@ -229,6 +233,10 @@ command instead of a `pip install` side effect. To set up only one provider, use
 `sidepulse setup codex`, `sidepulse setup claude`, or `sidepulse setup grok`.
 To skip the status-bar app but still install hooks and SidePulse Pro Eject Prevention, use
 `sidepulse setup --no-status-bar`.
+
+Hermes integration is installed separately through Hermes' plugin manager; see
+[`integrations/hermes`](integrations/hermes/). `sidepulse setup` intentionally does
+not modify Hermes configuration.
 
 SidePulse Pro Eject Prevention keeps the built-in SD reader attached after
 macOS hibernate or lock-screen mount refusals. By default setup installs it

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Agent status modes:
 | Waiting for Input | The agent needs a user decision, approval, or additional context. | Slow amber pulse. |
 | Long Task Progress | A longer job has measurable progress. | Cyan rolling animation. |
 | Blocked / Error | The agent cannot continue, a tool failed, or a recoverable error needs attention. | Slow amber pulse. |
-| Completed | The agent finished successfully. | Solid green. |
+| Completed | The agent finished successfully. | Solid green for 12 seconds, then idle. |
 
 When multiple states are active, SidePulse should show the most actionable
 mode first: Blocked / Error, Waiting for Input, Tool Running, Long Task
@@ -122,6 +122,26 @@ Aggregation priority:
 | 5 | Working | Show while one or more agents are actively processing. |
 | 6 | Completed | Show briefly when the latest active agent completes successfully. |
 | 7 | Idle / Ready | Show only when all known agents are idle or no fresh agent status exists. |
+
+The device only has four LED patterns for those seven modes: dim idle pulse,
+cyan roll, amber pulse, and solid green. Working, Tool Running, and Long Task
+Progress share cyan. Waiting for Input and Blocked / Error share amber.
+
+Display rules:
+
+- Completed stays solid green for 12 seconds, then the aggregate returns to
+  Idle / Ready.
+- `Show Battery on Plug/Unplug` never overrides Working, Tool Running,
+  Waiting, Long Task, or Blocked. Battery preview is also debounced so a
+  flapping MagSafe connection cannot keep stealing the LEDs.
+- A `PermissionRequest` shorter than two seconds is shown as Working. Hermes
+  emits that event around auto-approved `terminal` / `execute_code` calls; the
+  amber Ask pulse is reserved for an approval that actually lingers.
+- Hermes `PostToolUseFailure` is shown as Working. A failed tool that the
+  agent continues past is not a blocked LED state. Approval denials and API
+  failures still use Blocked / Error.
+- Hermes `PostToolUse` stays Working while the model thinks. Codex still
+  expires a stale post-tool Working state after two minutes.
 
 Agent statuses should include a timestamp. SidePulse should ignore stale
 statuses after a short timeout so disconnected or finished agents do not hold
@@ -440,7 +460,8 @@ reconnect.
 The dropdown and Settings window can switch the LEDs between agent status and
 battery status. When agent status is selected, `Show Battery on Plug/Unplug`
 can briefly show the battery animation for seven seconds after the power source
-changes.
+changes, but only while every agent is Idle or Completed. Active agent work
+keeps the cyan or amber status animation.
 
 The Devices section also offers **Add Screen Bar**, an optional virtual
 eight-LED device. It appears as a notch-shaped status-bar overlay that covers

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -9,6 +9,7 @@ The plugin sends only lifecycle metadata needed to render status:
 - event name and normalized SidePulse mode
 - timestamp
 - configured agent/profile label plus an opaque, session-scoped status suffix
+- active Hermes profile name (never its filesystem path), used to resolve that profile's session lineage safely
 - Hermes provider label
 - durable Hermes session and turn identifiers
 - client surface/origin label
@@ -51,7 +52,29 @@ hermes plugins install inteliwear/sidepulse/integrations/hermes \
   --enable
 ```
 
-Restart each long-running Hermes runtime after installation. For Hermes Desktop, quit and reopen the application.
+SidePulse declares `profile_scope: shared`. On Hermes versions that support shared
+user plugins, the single root installation above is discovered by every local
+profile, including agents launched from the Desktop **Bots** screen. Root
+`plugins.enabled` remains the global consent gate; no per-profile plugin copy is
+needed.
+
+An individual profile may opt out and later rejoin without changing the root
+installation:
+
+```bash
+hermes --profile homelab plugins disable hermes-sidepulse
+hermes --profile homelab plugins enable hermes-sidepulse
+```
+
+`hermes --profile homelab plugins list --plain --no-bundled` reports the plugin
+with source `shared`. Older Hermes releases that do not understand
+`profile_scope` keep their existing profile-isolated behavior and require a
+separate installation in each profile.
+
+Restart each long-running Hermes runtime after installation or after adding
+shared-plugin support. For Hermes Desktop, wait for active turns to finish and
+restart only the affected profile backend when possible; a full application
+restart is not intrinsically required.
 
 ## Configuration
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -106,19 +106,61 @@ hermes sidepulse doctor --json
 hermes sidepulse test --mode working
 hermes sidepulse test --mode ask
 hermes sidepulse test --mode done
-hermes sidepulse compat
-```
-
-`hermes sidepulse compat` (or the standalone script below) is the post-upgrade check. It fails if Hermes dropped a required lifecycle hook, the plugin is missing/disabled, the status-bar socket is down, or synthetic Working/Ask/Done events no longer emit.
-
-```bash
-python3 integrations/hermes/scripts/check_hermes_compat.py
-python3 integrations/hermes/scripts/check_hermes_compat.py --update-baseline
 ```
 
 Available test modes are `idle`, `working`, `tool`, `ask`, `done`, and `error`.
 
 The status-bar socket is intentionally best-effort. If the monitor is not running, Hermes continues normally and, when `log_events` is enabled, the plugin still writes the privacy-safe event log for diagnosis.
+
+## Compatibility check after a Hermes update
+
+Run this after upgrading Hermes, or whenever the LEDs look wrong. It is the
+check that tells you whether SidePulse still matches the live Hermes plugin
+API.
+
+Preferred, if the plugin still loads:
+
+```bash
+hermes sidepulse compat
+```
+
+Standalone, even if the plugin failed to register after the upgrade:
+
+```bash
+python3 integrations/hermes/scripts/check_hermes_compat.py
+```
+
+What it checks:
+
+1. Hermes is on `PATH` and reports a version.
+2. The live Hermes `VALID_HOOKS` set still includes every hook this plugin
+   needs (`on_session_start`, `on_session_activate`, `on_session_reset`,
+   `pre_llm_call`, `pre_tool_call`, `post_tool_call`, `pre_approval_request`,
+   `post_approval_response`, `api_request_error`, `post_llm_call`,
+   `on_session_end`).
+3. `hermes-sidepulse` is listed and enabled.
+4. The SidePulse status-bar socket is up.
+5. Synthetic Working, Ask, and Done events still emit and get logged.
+
+Exit codes:
+
+- `0` — contract intact. SidePulse should still work.
+- `1` — something needs a fix before trusting the LEDs.
+
+Useful flags:
+
+```bash
+hermes sidepulse compat --json
+python3 integrations/hermes/scripts/check_hermes_compat.py --json
+python3 integrations/hermes/scripts/check_hermes_compat.py --update-baseline
+```
+
+`--update-baseline` writes the current Hermes version and hook set to
+`~/.local/state/sidepulse/agent-monitor/hermes-compat-baseline.json`. The next
+run will also report version drift and any required hooks that disappeared.
+
+If the check fails, use the recovery runbook and the custom-work checklist
+rather than reinstalling blindly.
 
 ## Status LEDs
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -106,6 +106,14 @@ hermes sidepulse doctor --json
 hermes sidepulse test --mode working
 hermes sidepulse test --mode ask
 hermes sidepulse test --mode done
+hermes sidepulse compat
+```
+
+`hermes sidepulse compat` (or the standalone script below) is the post-upgrade check. It fails if Hermes dropped a required lifecycle hook, the plugin is missing/disabled, the status-bar socket is down, or synthetic Working/Ask/Done events no longer emit.
+
+```bash
+python3 integrations/hermes/scripts/check_hermes_compat.py
+python3 integrations/hermes/scripts/check_hermes_compat.py --update-baseline
 ```
 
 Available test modes are `idle`, `working`, `tool`, `ask`, `done`, and `error`.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -112,6 +112,26 @@ Available test modes are `idle`, `working`, `tool`, `ask`, `done`, and `error`.
 
 The status-bar socket is intentionally best-effort. If the monitor is not running, Hermes continues normally and, when `log_events` is enabled, the plugin still writes the privacy-safe event log for diagnosis.
 
+## Status LEDs
+
+The plugin reports the modes in the main [SidePulse README](../../README.md#ai-agent-monitoring). Hermes does not emit Long Task Progress. Visually, SidePulse uses four LED patterns:
+
+| Plugin mode | Typical Hermes hook | LED |
+|---|---|---|
+| `idle_ready` | session start / inactive activate | Dim idle pulse |
+| `working` | `pre_llm_call`, successful `post_tool_call` | Cyan roll |
+| `tool_running` | `pre_tool_call` | Cyan roll |
+| `waiting_for_input` | `pre_approval_request`, `clarify`, a final `?` | Amber pulse |
+| `blocked_error` | denied approval, API error | Amber pulse |
+| `completed` | successful `post_llm_call` | Solid green for 12s, then idle |
+
+The status-bar app then applies these display rules so the device stays glanceable:
+
+- Completed is a 12-second green flash, then Idle / Ready.
+- A `PermissionRequest` shorter than two seconds stays Working. Hermes fires that hook around auto-approved `terminal` / `execute_code` calls; amber is only for an approval that actually waits.
+- Hermes `PostToolUseFailure` stays Working. A failed tool the agent continues past is not Blocked on the LEDs.
+- Battery plug/unplug preview never overrides an active agent mode.
+
 ## Migrate from shell hooks
 
 If Hermes was previously connected to SidePulse with custom shell hooks, disable those hooks after confirming the plugin works. Running both integrations duplicates events. Keep a backup until a live Hermes turn has produced the expected SidePulse state transitions.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,105 @@
+# SidePulse integration for Hermes Agent
+
+This directory contains an installable [Hermes Agent](https://hermes-agent.nousresearch.com/) lifecycle plugin. It reports Hermes session, LLM, tool, approval, and error states to the local SidePulse status-bar socket.
+
+## Privacy model
+
+The plugin sends only lifecycle metadata needed to render status:
+
+- event name and normalized SidePulse mode
+- timestamp
+- configured agent/profile label plus an opaque, session-scoped status suffix
+- Hermes provider label
+- durable Hermes session and turn identifiers
+- client surface/origin label
+- tool name, but never tool arguments or results
+
+It does **not** send prompts, messages, conversation history, approval details, tool arguments, tool results, response bodies, or approval routing keys. `session_key` values are never promoted to durable session identifiers or written to the socket/log. Final-response text is inspected in memory only to distinguish `completed`, `waiting`, and `idle_ready`; the text is never added to the emitted event or debug log.
+
+Approval hook `surface` values describe the approval mechanism rather than the originating client. The plugin therefore correlates approvals to an already-observed durable session and client surface in memory. Because Hermes may reload a directory plugin between lifecycle callbacks, a cache miss performs a bounded reverse lookup in the existing owner-only metadata log for the same durable session ID. Recovery reads at most the 1 MiB ending at the observed file size, accepts only normalized client-surface tokens, and rejects approval-only lifecycle records and approval-transport values; it adds no new persisted fields or files. If no safe correlation exists, the plugin reports the client surface as `unknown` instead of guessing.
+
+The plugin registers no model-facing tools, so it adds no tool schema to model prompts.
+
+## Prerequisites
+
+1. Install SidePulse and run its setup flow:
+
+   ```bash
+   uv tool install git+https://github.com/inteliwear/sidepulse
+   sidepulse setup
+   ```
+
+2. Confirm the SidePulse status-bar monitor is running and its local socket appears at:
+
+   ```text
+   ~/.local/state/sidepulse/agent-monitor/events.sock
+   ```
+
+## Install
+
+Hermes supports plugins stored in a repository subdirectory:
+
+```bash
+hermes plugins install inteliwear/sidepulse/integrations/hermes --enable
+```
+
+For reproducible deployments, pin a reviewed SidePulse commit:
+
+```bash
+hermes plugins install inteliwear/sidepulse/integrations/hermes \
+  --ref <40-character-commit-sha> \
+  --enable
+```
+
+Restart each long-running Hermes runtime after installation. For Hermes Desktop, quit and reopen the application.
+
+## Configuration
+
+The default label is the active Hermes profile name. To use a friendlier SidePulse label, configure the plugin under its manifest name. The plugin appends an opaque 12-hex session suffix internally so concurrent sessions from the same profile remain independent:
+
+```yaml
+plugins:
+  entries:
+    hermes-sidepulse:
+      settings:
+        agent_id: EDI
+```
+
+Optional settings:
+
+| Setting | Default | Purpose |
+|---|---:|---|
+| `agent_id` | active profile name | SidePulse display-label prefix; status identity is session-scoped |
+| `state_dir` | SidePulse XDG state path | Event-log directory override |
+| `socket_path` | `<state_dir>/events.sock` | Local Unix socket override |
+| `socket_timeout` | `0.2` | Best-effort socket timeout in seconds |
+| `log_events` | `true` | Append privacy-safe metadata to owner-only `hermes.jsonl` and support cross-reload provenance recovery |
+
+## Diagnose and test
+
+```bash
+hermes sidepulse doctor
+hermes sidepulse doctor --json
+hermes sidepulse test --mode working
+hermes sidepulse test --mode ask
+hermes sidepulse test --mode done
+```
+
+Available test modes are `idle`, `working`, `tool`, `ask`, `done`, and `error`.
+
+The status-bar socket is intentionally best-effort. If the monitor is not running, Hermes continues normally and, when `log_events` is enabled, the plugin still writes the privacy-safe event log for diagnosis.
+
+## Migrate from shell hooks
+
+If Hermes was previously connected to SidePulse with custom shell hooks, disable those hooks after confirming the plugin works. Running both integrations duplicates events. Keep a backup until a live Hermes turn has produced the expected SidePulse state transitions.
+
+## Development
+
+From the SidePulse repository root:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_hermes_plugin.py' -v
+hermes plugins doctor
+```
+
+The unit tests cover lifecycle translation, routing-key privacy boundaries, approval provenance/failure mapping, cross-registration provenance recovery, concurrent-session identity, owner-only fallback logging, best-effort socket delivery, registration, diagnostics, and synthetic test events.

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -46,7 +46,7 @@ def _boolean_setting(value: Any, *, default: bool) -> bool:
 
 
 def _settings_from_context(ctx) -> PluginSettings:
-    profile_name = str(getattr(ctx, "profile_name", "") or "Hermes").strip()
+    profile_name = str(getattr(ctx, "profile_name", "") or "").strip()
     agent_id = str(ctx.get_config("agent_id", default="") or "").strip() or profile_name
     timeout_value = ctx.get_config("socket_timeout", default=0.2)
     try:
@@ -55,6 +55,7 @@ def _settings_from_context(ctx) -> PluginSettings:
         socket_timeout = 0.2
     return PluginSettings(
         agent_id=agent_id,
+        profile_name=profile_name,
         state_dir=_optional_path(ctx.get_config("state_dir", default="")),
         socket_path=_optional_path(ctx.get_config("socket_path", default="")),
         socket_timeout=socket_timeout,
@@ -78,6 +79,14 @@ def _observer(
             sessions_by_turn[turn_id] = session_id
         elif turn_id:
             session_id = sessions_by_turn.get(turn_id, "")
+
+        # SidePulse identities are session-scoped. A shared observer can see
+        # tool hooks without durable session context; emitting those would
+        # create an independent active agent that no completion can clear.
+        if not session_id:
+            return
+        if not str(settings.profile_name or "").strip():
+            return
 
         platform = str(kwargs.get("platform") or "").strip()
         hook_surface = str(kwargs.get("surface") or "").strip()

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -88,6 +88,11 @@ def _observer(
             return
         if not str(settings.profile_name or "").strip():
             return
+        # Hermes background memory/skill reviews reuse the foreground session id
+        # and platform. They are hidden maintenance work, not user activity, so
+        # never let them create or refresh SidePulse status.
+        if bool(kwargs.get("background_review")):
+            return
 
         platform = str(kwargs.get("platform") or "").strip()
         hook_surface = str(kwargs.get("surface") or "").strip()

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -1,0 +1,137 @@
+"""Hermes lifecycle integration for SidePulse."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .bridge import PluginSettings, emit_hook, recover_session_surface
+from .diagnostics import handle_cli, setup_cli
+
+HOOK_NAMES = (
+    "on_session_start",
+    "on_session_reset",
+    "pre_llm_call",
+    "pre_tool_call",
+    "post_tool_call",
+    "pre_approval_request",
+    "post_approval_response",
+    "api_request_error",
+    "post_llm_call",
+    "on_session_end",
+)
+
+
+def _optional_path(value: Any) -> Path | None:
+    text = str(value or "").strip()
+    return Path(text).expanduser() if text else None
+
+
+def _boolean_setting(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _settings_from_context(ctx) -> PluginSettings:
+    profile_name = str(getattr(ctx, "profile_name", "") or "Hermes").strip()
+    agent_id = str(ctx.get_config("agent_id", default="") or "").strip() or profile_name
+    timeout_value = ctx.get_config("socket_timeout", default=0.2)
+    try:
+        socket_timeout = max(0.01, min(float(timeout_value), 5.0))
+    except (TypeError, ValueError):
+        socket_timeout = 0.2
+    return PluginSettings(
+        agent_id=agent_id,
+        state_dir=_optional_path(ctx.get_config("state_dir", default="")),
+        socket_path=_optional_path(ctx.get_config("socket_path", default="")),
+        socket_timeout=socket_timeout,
+        log_events=_boolean_setting(
+            ctx.get_config("log_events", default=True),
+            default=True,
+        ),
+    )
+
+
+def _observer(
+    hook_name: str,
+    settings: PluginSettings,
+    surfaces_by_session: dict[str, str],
+    sessions_by_turn: dict[str, str],
+):
+    def callback(**kwargs: Any) -> None:
+        session_id = str(kwargs.get("session_id") or "").strip()
+        turn_id = str(kwargs.get("turn_id") or "").strip()
+        if session_id and turn_id:
+            sessions_by_turn[turn_id] = session_id
+        elif turn_id:
+            session_id = sessions_by_turn.get(turn_id, "")
+
+        platform = str(kwargs.get("platform") or "").strip()
+        hook_surface = str(kwargs.get("surface") or "").strip()
+        is_approval_hook = hook_name in {
+            "pre_approval_request",
+            "post_approval_response",
+        }
+        client_surface = platform or ("" if is_approval_hook else hook_surface)
+        if session_id and client_surface:
+            surfaces_by_session[session_id] = client_surface
+
+        updates: dict[str, str] = {}
+        if is_approval_hook and "surface" in kwargs:
+            kwargs = {key: value for key, value in kwargs.items() if key != "surface"}
+        if session_id and not kwargs.get("session_id"):
+            updates["session_id"] = session_id
+        cached_surface = surfaces_by_session.get(session_id, "")
+        if session_id and not cached_surface and not client_surface:
+            cached_surface = recover_session_surface(settings, session_id)
+            if cached_surface:
+                surfaces_by_session[session_id] = cached_surface
+        if cached_surface and (is_approval_hook or not client_surface):
+            updates["platform"] = cached_surface
+        elif is_approval_hook and not platform:
+            updates["platform"] = "unknown"
+        if updates:
+            kwargs = {**kwargs, **updates}
+        try:
+            emit_hook(hook_name, kwargs, settings)
+        except Exception:  # noqa: BLE001, S110 - observer must never break Hermes
+            pass
+        finally:
+            if hook_name == "on_session_end" and session_id:
+                surfaces_by_session.pop(session_id, None)
+                for known_turn, known_session in list(sessions_by_turn.items()):
+                    if known_session == session_id:
+                        sessions_by_turn.pop(known_turn, None)
+
+    return callback
+
+
+def register(ctx) -> None:
+    """Register SidePulse as an observer-only Hermes lifecycle plugin."""
+
+    settings = _settings_from_context(ctx)
+    surfaces_by_session: dict[str, str] = {}
+    sessions_by_turn: dict[str, str] = {}
+    for hook_name in HOOK_NAMES:
+        ctx.register_hook(
+            hook_name,
+            _observer(
+                hook_name,
+                settings,
+                surfaces_by_session,
+                sessions_by_turn,
+            ),
+        )
+    ctx.register_cli_command(
+        name="sidepulse",
+        help="Inspect the Hermes SidePulse integration",
+        setup_fn=setup_cli,
+        handler_fn=lambda args: handle_cli(args, settings),
+    )

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .bridge import PluginSettings, emit_hook, recover_session_surface
+from .bridge import (
+    PluginSettings,
+    emit_hook,
+    recover_session_mode,
+    recover_session_surface,
+)
 from .diagnostics import handle_cli, setup_cli
 
 HOOK_NAMES = (
     "on_session_start",
+    "on_session_activate",
     "on_session_reset",
     "pre_llm_call",
     "pre_tool_call",
@@ -84,6 +90,16 @@ def _observer(
             surfaces_by_session[session_id] = client_surface
 
         updates: dict[str, str] = {}
+        if hook_name == "on_session_activate":
+            if bool(kwargs.get("running")):
+                previous_mode = recover_session_mode(settings, session_id)
+                updates["activation_mode"] = (
+                    "waiting_for_input"
+                    if previous_mode == "waiting_for_input"
+                    else "working"
+                )
+            else:
+                updates["activation_mode"] = "idle_ready"
         if is_approval_hook and "surface" in kwargs:
             kwargs = {key: value for key, value in kwargs.items() if key != "surface"}
         if session_id and not kwargs.get("session_id"):

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -25,6 +25,7 @@ HOOK_NAMES = (
     "api_request_error",
     "post_llm_call",
     "on_session_end",
+    "on_session_finalize",
 )
 
 
@@ -129,7 +130,7 @@ def _observer(
         except Exception:  # noqa: BLE001, S110 - observer must never break Hermes
             pass
         finally:
-            if hook_name == "on_session_end" and session_id:
+            if hook_name in {"on_session_end", "on_session_finalize"} and session_id:
                 surfaces_by_session.pop(session_id, None)
                 for known_turn, known_session in list(sessions_by_turn.items()):
                     if known_session == session_id:

--- a/integrations/hermes/bridge.py
+++ b/integrations/hermes/bridge.py
@@ -1,0 +1,299 @@
+"""Translate Hermes lifecycle hooks into SidePulse status events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import socket
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_SURFACE_RECOVERY_WINDOW_BYTES = 1024 * 1024
+_SURFACE_TOKEN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_APPROVAL_EVENT_NAMES = {"PermissionRequest", "PermissionDenied"}
+
+
+@dataclass(frozen=True)
+class PluginSettings:
+    """Privacy-safe identity and transport settings for SidePulse events."""
+
+    agent_id: str = "Hermes"
+    provider: str = "hermes"
+    state_dir: Path | None = None
+    socket_path: Path | None = None
+    socket_timeout: float = 0.2
+    log_events: bool = True
+
+    def resolved_state_dir(self) -> Path:
+        if self.state_dir is not None:
+            return Path(self.state_dir).expanduser()
+        xdg_state_home = os.environ.get("XDG_STATE_HOME")
+        base = (
+            Path(xdg_state_home).expanduser()
+            if xdg_state_home
+            else Path.home() / ".local" / "state"
+        )
+        return base / "sidepulse" / "agent-monitor"
+
+    def resolved_socket_path(self) -> Path:
+        if self.socket_path is not None:
+            return Path(self.socket_path).expanduser()
+        return self.resolved_state_dir() / "events.sock"
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    event: dict[str, Any] | None
+    logged: bool
+    delivered: bool
+
+
+def _status_agent_id(label: str, session_id: Any) -> str:
+    durable_session_id = str(session_id or "").strip()
+    if not durable_session_id:
+        return label
+    suffix = hashlib.sha256(durable_session_id.encode("utf-8")).hexdigest()[:12]
+    return f"{label}:{suffix}"
+
+
+def _surface_metadata(platform: Any) -> tuple[str, str, str]:
+    surface = str(platform or "unknown").strip().lower() or "unknown"
+    if surface == "unknown":
+        return surface, "Hermes", "hermes"
+    if surface == "desktop":
+        return surface, "Hermes Desktop", "hermes_desktop"
+    if surface in {"cli", "terminal"}:
+        return surface, "Hermes CLI", "hermes_cli"
+    return surface, f"Hermes {surface.title()}", f"hermes_{surface.replace('-', '_')}"
+
+
+def recover_session_surface(
+    settings: PluginSettings,
+    session_id: Any,
+) -> str:
+    """Recover safe client provenance after Hermes reloads the plugin module."""
+
+    durable_session_id = str(session_id or "").strip()
+    if not durable_session_id or not settings.log_events:
+        return ""
+    try:
+        target = settings.resolved_state_dir() / f"{settings.provider}.jsonl"
+        with open(target, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            end = handle.tell()
+            start = max(0, end - _SURFACE_RECOVERY_WINDOW_BYTES)
+            handle.seek(start)
+            data = handle.read(end - start)
+        if start:
+            _, _, data = data.partition(b"\n")
+        for raw_line in reversed(data.splitlines()):
+            try:
+                event = json.loads(raw_line)
+            except (RecursionError, TypeError, ValueError):
+                continue
+            if not isinstance(event, Mapping):
+                continue
+            if event.get("session_id") != durable_session_id:
+                continue
+            if event.get("hook_event_name") in _APPROVAL_EVENT_NAMES:
+                continue
+            surface = str(event.get("surface") or "").strip().lower()
+            if (
+                surface == "unknown"
+                or surface in {"gateway", "smart"}
+                or surface.startswith("transport")
+                or not _SURFACE_TOKEN.fullmatch(surface)
+            ):
+                continue
+            return surface
+    except (OSError, TypeError, ValueError):
+        return ""
+    return ""
+
+
+def _final_mode(response: Any) -> str:
+    text = response if isinstance(response, str) else ""
+    markers = re.findall(
+        r"<!--\s*sidepulse\s*:\s*([a-z0-9_ -]+)\s*-->",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if markers:
+        normalized = re.sub(r"[^a-z0-9]+", "_", markers[-1].lower()).strip("_")
+        explicit = {
+            "ask": "waiting_for_input",
+            "question": "waiting_for_input",
+            "waiting": "waiting_for_input",
+            "waiting_for_input": "waiting_for_input",
+            "blocked": "blocked_error",
+            "error": "blocked_error",
+            "blocked_error": "blocked_error",
+            "working": "working",
+            "tool_running": "tool_running",
+            "done": "completed",
+            "complete": "completed",
+            "completed": "completed",
+            "idle": "idle_ready",
+            "ready": "idle_ready",
+            "idle_ready": "idle_ready",
+        }.get(normalized)
+        if explicit:
+            return explicit
+
+    visible = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    visible = re.sub(r"`[^`\n]*`", " ", visible)
+    visible = re.sub(r"<!--.*?-->", " ", visible, flags=re.DOTALL)
+    visible = " ".join(visible.split()).strip()
+    if not visible:
+        return "completed"
+    casual_questions = (
+        "anything else?",
+        "what else can i help with?",
+        "need anything else?",
+    )
+    if any(visible.lower().endswith(question) for question in casual_questions):
+        return "completed"
+    return "waiting_for_input" if visible.endswith("?") else "completed"
+
+
+def _event_mapping(
+    hook_name: str, payload: Mapping[str, Any]
+) -> tuple[str, str] | None:
+    if hook_name == "on_session_start" or hook_name == "on_session_reset":
+        return "SessionStart", "idle_ready"
+    if hook_name == "pre_llm_call":
+        return "UserPromptSubmit", "working"
+    if hook_name == "pre_tool_call":
+        if str(payload.get("tool_name") or "").strip() == "clarify":
+            return "PermissionRequest", "waiting_for_input"
+        return "PreToolUse", "tool_running"
+    if hook_name == "post_tool_call":
+        if str(payload.get("status") or "ok").strip().lower() in {"error", "blocked"}:
+            return "PostToolUseFailure", "blocked_error"
+        return "PostToolUse", "working"
+    if hook_name == "pre_approval_request":
+        return "PermissionRequest", "waiting_for_input"
+    if hook_name == "post_approval_response":
+        choice = str(payload.get("choice") or "").strip().lower()
+        if choice not in {"once", "session", "always", "smart_approve"}:
+            return "PermissionDenied", "blocked_error"
+        return "UserPromptSubmit", "working"
+    if hook_name == "api_request_error":
+        return "StopFailure", "blocked_error"
+    if hook_name == "post_llm_call":
+        return "Stop", _final_mode(payload.get("assistant_response"))
+    if hook_name == "on_session_end":
+        if bool(payload.get("completed")) and not bool(payload.get("interrupted")):
+            return None
+        if bool(payload.get("interrupted")):
+            return "SessionStart", "idle_ready"
+        return "StopFailure", "blocked_error"
+    return None
+
+
+def translate_hook(
+    hook_name: str,
+    payload: Mapping[str, Any],
+    settings: PluginSettings,
+    *,
+    now: str,
+) -> dict[str, Any] | None:
+    """Return a SidePulse event containing status metadata only."""
+
+    mapping = _event_mapping(hook_name, payload)
+    if mapping is None:
+        return None
+    target_event, mode = mapping
+
+    surface, origin, origin_kind = _surface_metadata(
+        payload.get("platform") or payload.get("surface")
+    )
+    session_id = payload.get("session_id")
+    event: dict[str, Any] = {
+        "logged_at": now,
+        "hook_event_name": target_event,
+        "integration": "hermes-plugin",
+        "agent_id": _status_agent_id(settings.agent_id, session_id),
+        "agent_origin": origin,
+        "agent_origin_kind": origin_kind,
+        "sidepulse_mode": mode,
+    }
+    if isinstance(session_id, str) and session_id.strip():
+        event["session_id"] = session_id.strip()
+    turn_id = payload.get("turn_id")
+    if isinstance(turn_id, str) and turn_id.strip():
+        event["turn_id"] = turn_id.strip()
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        event["tool_name"] = tool_name.strip()
+    event["surface"] = surface
+    return event
+
+
+def _append_event(event: Mapping[str, Any], settings: PluginSettings) -> bool:
+    if not settings.log_events:
+        return False
+    try:
+        target = settings.resolved_state_dir() / f"{settings.provider}.jsonl"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, separators=(",", ":"), ensure_ascii=False) + "\n"
+        descriptor = os.open(
+            target,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o600,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "a", encoding="utf-8") as handle:
+                descriptor = -1
+                handle.write(line)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        return True
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def _send_event(event: Mapping[str, Any], settings: PluginSettings) -> bool:
+    try:
+        message = json.dumps(
+            {"provider": settings.provider, "line": event},
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        if len(message) > 1024 * 1024:
+            return False
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(settings.socket_timeout)
+        try:
+            client.connect(str(settings.resolved_socket_path()))
+            client.sendall(message)
+            return True
+        finally:
+            client.close()
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def emit_hook(
+    hook_name: str,
+    payload: Mapping[str, Any],
+    settings: PluginSettings,
+    *,
+    now: str | None = None,
+) -> DeliveryResult:
+    """Translate, log, and best-effort deliver one Hermes hook event."""
+
+    timestamp = now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    event = translate_hook(hook_name, payload, settings, now=timestamp)
+    if event is None:
+        return DeliveryResult(event=None, logged=False, delivered=False)
+    logged = _append_event(event, settings)
+    delivered = _send_event(event, settings)
+    return DeliveryResult(event=event, logged=logged, delivered=delivered)

--- a/integrations/hermes/bridge.py
+++ b/integrations/hermes/bridge.py
@@ -207,6 +207,7 @@ def _final_mode(response: Any) -> str:
         "anything else?",
         "what else can i help with?",
         "need anything else?",
+        "what do you want to work on?",
     )
     if any(visible.lower().endswith(question) for question in casual_questions):
         return "completed"

--- a/integrations/hermes/bridge.py
+++ b/integrations/hermes/bridge.py
@@ -245,6 +245,8 @@ def _event_mapping(
         return "StopFailure", "blocked_error"
     if hook_name == "post_llm_call":
         return "Stop", _final_mode(payload.get("assistant_response"))
+    if hook_name == "on_session_finalize":
+        return "SessionFinalize", "completed"
     if hook_name == "on_session_end":
         if bool(payload.get("completed")) and not bool(payload.get("interrupted")):
             return None

--- a/integrations/hermes/bridge.py
+++ b/integrations/hermes/bridge.py
@@ -23,6 +23,7 @@ class PluginSettings:
     """Privacy-safe identity and transport settings for SidePulse events."""
 
     agent_id: str = "Hermes"
+    profile_name: str = ""
     provider: str = "hermes"
     state_dir: Path | None = None
     socket_path: Path | None = None
@@ -53,11 +54,17 @@ class DeliveryResult:
     delivered: bool
 
 
-def _status_agent_id(label: str, session_id: Any) -> str:
+def _status_agent_id(
+    label: str,
+    session_id: Any,
+    profile_name: Any = "",
+) -> str:
     durable_session_id = str(session_id or "").strip()
     if not durable_session_id:
         return label
-    suffix = hashlib.sha256(durable_session_id.encode("utf-8")).hexdigest()[:12]
+    profile = str(profile_name or "").strip()
+    identity = f"{profile}\0{durable_session_id}" if profile else durable_session_id
+    suffix = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
     return f"{label}:{suffix}"
 
 
@@ -79,9 +86,14 @@ def _recent_session_events(
     """Return bounded, newest-first metadata events for one durable session."""
 
     durable_session_id = str(session_id or "").strip()
-    if not durable_session_id or not settings.log_events:
+    expected_profile = str(settings.profile_name or "").strip()
+    if not durable_session_id or not settings.log_events or not expected_profile:
         return ()
-    expected_agent_id = _status_agent_id(settings.agent_id, durable_session_id)
+    expected_agent_id = _status_agent_id(
+        settings.agent_id,
+        durable_session_id,
+        expected_profile,
+    )
     try:
         target = settings.resolved_state_dir() / f"{settings.provider}.jsonl"
         with open(target, "rb") as handle:
@@ -103,6 +115,8 @@ def _recent_session_events(
             if event.get("session_id") != durable_session_id:
                 continue
             if event.get("integration") != "hermes-plugin":
+                continue
+            if event.get("hermes_profile") != expected_profile:
                 continue
             if event.get("agent_id") != expected_agent_id:
                 continue
@@ -251,6 +265,8 @@ def translate_hook(
     mapping = _event_mapping(hook_name, payload)
     if mapping is None:
         return None
+    if not str(settings.profile_name or "").strip():
+        return None
     target_event, mode = mapping
 
     surface, origin, origin_kind = _surface_metadata(
@@ -261,13 +277,20 @@ def translate_hook(
         "logged_at": now,
         "hook_event_name": target_event,
         "integration": "hermes-plugin",
-        "agent_id": _status_agent_id(settings.agent_id, session_id),
+        "agent_id": _status_agent_id(
+            settings.agent_id,
+            session_id,
+            settings.profile_name,
+        ),
         "agent_origin": origin,
         "agent_origin_kind": origin_kind,
         "sidepulse_mode": mode,
     }
     if isinstance(session_id, str) and session_id.strip():
         event["session_id"] = session_id.strip()
+    profile_name = str(settings.profile_name or "").strip()
+    if profile_name:
+        event["hermes_profile"] = profile_name
     turn_id = payload.get("turn_id")
     if isinstance(turn_id, str) and turn_id.strip():
         event["turn_id"] = turn_id.strip()

--- a/integrations/hermes/bridge.py
+++ b/integrations/hermes/bridge.py
@@ -264,6 +264,11 @@ def translate_hook(
     now: str,
 ) -> dict[str, Any] | None:
     """Return a SidePulse event containing status metadata only."""
+    # Background memory/skill reviews reuse the foreground session id and
+    # platform for prompt-cache warmth. They are not user-facing activity and
+    # must not change the agent's Working/Done/Ask state.
+    if bool(payload.get("background_review")):
+        return None
 
     mapping = _event_mapping(hook_name, payload)
     if mapping is None:

--- a/integrations/hermes/bridge.py
+++ b/integrations/hermes/bridge.py
@@ -72,15 +72,16 @@ def _surface_metadata(platform: Any) -> tuple[str, str, str]:
     return surface, f"Hermes {surface.title()}", f"hermes_{surface.replace('-', '_')}"
 
 
-def recover_session_surface(
+def _recent_session_events(
     settings: PluginSettings,
     session_id: Any,
-) -> str:
-    """Recover safe client provenance after Hermes reloads the plugin module."""
+) -> tuple[Mapping[str, Any], ...]:
+    """Return bounded, newest-first metadata events for one durable session."""
 
     durable_session_id = str(session_id or "").strip()
     if not durable_session_id or not settings.log_events:
-        return ""
+        return ()
+    expected_agent_id = _status_agent_id(settings.agent_id, durable_session_id)
     try:
         target = settings.resolved_state_dir() / f"{settings.provider}.jsonl"
         with open(target, "rb") as handle:
@@ -91,6 +92,7 @@ def recover_session_surface(
             data = handle.read(end - start)
         if start:
             _, _, data = data.partition(b"\n")
+        events: list[Mapping[str, Any]] = []
         for raw_line in reversed(data.splitlines()):
             try:
                 event = json.loads(raw_line)
@@ -100,6 +102,24 @@ def recover_session_surface(
                 continue
             if event.get("session_id") != durable_session_id:
                 continue
+            if event.get("integration") != "hermes-plugin":
+                continue
+            if event.get("agent_id") != expected_agent_id:
+                continue
+            events.append(event)
+        return tuple(events)
+    except (OSError, TypeError, ValueError):
+        return ()
+
+
+def recover_session_surface(
+    settings: PluginSettings,
+    session_id: Any,
+) -> str:
+    """Recover safe client provenance after Hermes reloads the plugin module."""
+
+    for event in _recent_session_events(settings, session_id):
+        try:
             if event.get("hook_event_name") in _APPROVAL_EVENT_NAMES:
                 continue
             surface = str(event.get("surface") or "").strip().lower()
@@ -111,8 +131,26 @@ def recover_session_surface(
             ):
                 continue
             return surface
-    except (OSError, TypeError, ValueError):
-        return ""
+        except (RecursionError, TypeError, ValueError):
+            continue
+    return ""
+
+
+def recover_session_mode(settings: PluginSettings, session_id: Any) -> str:
+    """Recover the most recent normalized status for a durable session."""
+
+    allowed = {
+        "idle_ready",
+        "working",
+        "tool_running",
+        "waiting_for_input",
+        "completed",
+        "blocked_error",
+    }
+    for event in _recent_session_events(settings, session_id):
+        mode = str(event.get("sidepulse_mode") or "").strip().lower()
+        if mode in allowed:
+            return mode
     return ""
 
 
@@ -166,6 +204,11 @@ def _event_mapping(
 ) -> tuple[str, str] | None:
     if hook_name == "on_session_start" or hook_name == "on_session_reset":
         return "SessionStart", "idle_ready"
+    if hook_name == "on_session_activate":
+        mode = str(payload.get("activation_mode") or "idle_ready").strip().lower()
+        if mode not in {"idle_ready", "working", "waiting_for_input"}:
+            mode = "idle_ready"
+        return "SessionActivate", mode
     if hook_name == "pre_llm_call":
         return "UserPromptSubmit", "working"
     if hook_name == "pre_tool_call":

--- a/integrations/hermes/diagnostics.py
+++ b/integrations/hermes/diagnostics.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -55,6 +57,12 @@ def setup_cli(parser) -> None:
     test = subcommands.add_parser("test", help="Emit a synthetic SidePulse status")
     test.add_argument("--mode", choices=sorted(_TEST_HOOKS), default="working")
     test.add_argument("--json", action="store_true", dest="as_json")
+    compat = subcommands.add_parser(
+        "compat",
+        help="Check that SidePulse still works after a Hermes update",
+    )
+    compat.add_argument("--json", action="store_true", dest="as_json")
+    compat.add_argument("--update-baseline", action="store_true")
     parser.set_defaults(sidepulse_command="doctor", as_json=False)
 
 
@@ -73,9 +81,40 @@ def _test_report(settings: PluginSettings, mode: str) -> dict[str, Any]:
     }
 
 
+def _compat_script() -> Path | None:
+    here = Path(__file__).resolve().parent
+    candidate = here / "scripts" / "check_hermes_compat.py"
+    return candidate if candidate.is_file() else None
+
+
 def handle_cli(args, settings: PluginSettings) -> None:
+    if getattr(args, "sidepulse_command", "doctor") == "compat":
+        script = _compat_script()
+        if script is None:
+            print("compat script missing: integrations/hermes/scripts/check_hermes_compat.py")
+            raise SystemExit(1)
+        command = [sys.executable, str(script)]
+        if getattr(args, "as_json", False):
+            command.append("--json")
+        if getattr(args, "update_baseline", False):
+            command.append("--update-baseline")
+        raise SystemExit(subprocess.call(command))
+
     if getattr(args, "sidepulse_command", "doctor") == "test":
-        report = _test_report(settings, getattr(args, "mode", "working"))
+        extra = dict(_TEST_HOOKS[getattr(args, "mode", "working")][1])
+        hook_name = _TEST_HOOKS[getattr(args, "mode", "working")][0]
+        payload = {
+            "platform": "cli",
+            "session_id": "hermes-sidepulse-test",
+            **extra,
+        }
+        result = emit_hook(hook_name, payload, settings)
+        report = {
+            "requested_mode": getattr(args, "mode", "working"),
+            "mode": (result.event or {}).get("sidepulse_mode"),
+            "logged": result.logged,
+            "delivered": result.delivered,
+        }
         if getattr(args, "as_json", False):
             print(json.dumps(report, sort_keys=True))
         else:

--- a/integrations/hermes/diagnostics.py
+++ b/integrations/hermes/diagnostics.py
@@ -1,0 +1,100 @@
+"""CLI diagnostics for the Hermes SidePulse plugin."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .bridge import PluginSettings, emit_hook
+
+_TEST_HOOKS = {
+    "idle": ("on_session_start", {}),
+    "working": ("pre_llm_call", {}),
+    "tool": ("pre_tool_call", {"tool_name": "sidepulse-test"}),
+    "ask": ("pre_approval_request", {}),
+    "done": ("post_llm_call", {"assistant_response": "<!-- sidepulse:done -->"}),
+    "error": ("api_request_error", {}),
+}
+
+
+def doctor_report(settings: PluginSettings) -> dict[str, Any]:
+    state_dir = settings.resolved_state_dir()
+    socket_path = settings.resolved_socket_path()
+    event_log = state_dir / f"{settings.provider}.jsonl"
+    latest_state = state_dir / "latest.json"
+    volumes = Path("/Volumes")
+    devices = []
+    if volumes.is_dir():
+        for candidate in sorted(volumes.iterdir()):
+            if (
+                candidate.name.lower().startswith("sidepulse")
+                or (candidate / "LEDS.LED").is_file()
+            ):
+                devices.append(str(candidate))
+    return {
+        "agent_id": settings.agent_id,
+        "provider": settings.provider,
+        "state_dir": str(state_dir),
+        "event_log_path": str(event_log),
+        "event_log_exists": event_log.is_file(),
+        "latest_state_path": str(latest_state),
+        "latest_state_exists": latest_state.is_file(),
+        "socket_path": str(socket_path),
+        "socket_exists": socket_path.exists(),
+        "sidepulse_command": shutil.which("sidepulse"),
+        "devices": devices,
+    }
+
+
+def setup_cli(parser) -> None:
+    subcommands = parser.add_subparsers(dest="sidepulse_command")
+    doctor = subcommands.add_parser("doctor", help="Inspect SidePulse transport health")
+    doctor.add_argument("--json", action="store_true", dest="as_json")
+    test = subcommands.add_parser("test", help="Emit a synthetic SidePulse status")
+    test.add_argument("--mode", choices=sorted(_TEST_HOOKS), default="working")
+    test.add_argument("--json", action="store_true", dest="as_json")
+    parser.set_defaults(sidepulse_command="doctor", as_json=False)
+
+
+def _test_report(settings: PluginSettings, mode: str) -> dict[str, Any]:
+    hook_name, extra = _TEST_HOOKS[mode]
+    result = emit_hook(
+        hook_name,
+        {"platform": "cli", "session_id": "hermes-sidepulse-test", **extra},
+        settings,
+    )
+    return {
+        "requested_mode": mode,
+        "mode": (result.event or {}).get("sidepulse_mode"),
+        "logged": result.logged,
+        "delivered": result.delivered,
+    }
+
+
+def handle_cli(args, settings: PluginSettings) -> None:
+    if getattr(args, "sidepulse_command", "doctor") == "test":
+        report = _test_report(settings, getattr(args, "mode", "working"))
+        if getattr(args, "as_json", False):
+            print(json.dumps(report, sort_keys=True))
+        else:
+            print(
+                f"SidePulse test: {report['mode']} "
+                f"(socket={'delivered' if report['delivered'] else 'unavailable'}, "
+                f"log={'written' if report['logged'] else 'not written'})"
+            )
+        return
+
+    report = doctor_report(settings)
+    if getattr(args, "as_json", False):
+        print(json.dumps(report, sort_keys=True))
+        return
+
+    print("Hermes SidePulse integration")
+    print(f"  agent: {report['agent_id']}")
+    print(f"  event log: {report['event_log_path']}")
+    print(f"  event socket: {report['socket_path']}")
+    print(f"  socket active: {'yes' if report['socket_exists'] else 'no'}")
+    print(f"  SidePulse CLI: {report['sidepulse_command'] or 'not found'}")
+    print(f"  devices: {', '.join(report['devices']) if report['devices'] else 'none'}")

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -18,6 +18,7 @@ hooks:
   - api_request_error
   - post_llm_call
   - on_session_end
+  - on_session_finalize
 provides_hooks:
   - on_session_start
   - on_session_activate
@@ -30,3 +31,4 @@ provides_hooks:
   - api_request_error
   - post_llm_call
   - on_session_end
+  - on_session_finalize

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -3,6 +3,7 @@ version: "0.1.0"
 description: Privacy-safe Hermes lifecycle status integration for SidePulse
 author: Cesar J. Garcia
 kind: standalone
+profile_scope: shared
 # `hooks` is consumed by Hermes v0.20; `provides_hooks` keeps the plugin
 # declaration explicit for newer doctor/index tooling.
 hooks:

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -7,6 +7,7 @@ kind: standalone
 # declaration explicit for newer doctor/index tooling.
 hooks:
   - on_session_start
+  - on_session_activate
   - on_session_reset
   - pre_llm_call
   - pre_tool_call
@@ -18,6 +19,7 @@ hooks:
   - on_session_end
 provides_hooks:
   - on_session_start
+  - on_session_activate
   - on_session_reset
   - pre_llm_call
   - pre_tool_call

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,0 +1,29 @@
+name: hermes-sidepulse
+version: "0.1.0"
+description: Privacy-safe Hermes lifecycle status integration for SidePulse
+author: Cesar J. Garcia
+kind: standalone
+# `hooks` is consumed by Hermes v0.20; `provides_hooks` keeps the plugin
+# declaration explicit for newer doctor/index tooling.
+hooks:
+  - on_session_start
+  - on_session_reset
+  - pre_llm_call
+  - pre_tool_call
+  - post_tool_call
+  - pre_approval_request
+  - post_approval_response
+  - api_request_error
+  - post_llm_call
+  - on_session_end
+provides_hooks:
+  - on_session_start
+  - on_session_reset
+  - pre_llm_call
+  - pre_tool_call
+  - post_tool_call
+  - pre_approval_request
+  - post_approval_response
+  - api_request_error
+  - post_llm_call
+  - on_session_end

--- a/integrations/hermes/scripts/check_hermes_compat.py
+++ b/integrations/hermes/scripts/check_hermes_compat.py
@@ -34,6 +34,7 @@ REQUIRED_HOOKS = (
     "api_request_error",
     "post_llm_call",
     "on_session_end",
+    "on_session_finalize",
 )
 
 PLUGIN_NAME = "hermes-sidepulse"

--- a/integrations/hermes/scripts/check_hermes_compat.py
+++ b/integrations/hermes/scripts/check_hermes_compat.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Check that SidePulse still works after a Hermes update.
+
+Run this after upgrading Hermes (or any time the LEDs look wrong):
+
+    python3 integrations/hermes/scripts/check_hermes_compat.py
+    hermes sidepulse compat
+
+Exit 0 if the contract is intact. Exit 1 if something needs a fix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REQUIRED_HOOKS = (
+    "on_session_start",
+    "on_session_activate",
+    "on_session_reset",
+    "pre_llm_call",
+    "pre_tool_call",
+    "post_tool_call",
+    "pre_approval_request",
+    "post_approval_response",
+    "api_request_error",
+    "post_llm_call",
+    "on_session_end",
+)
+
+PLUGIN_NAME = "hermes-sidepulse"
+DEFAULT_BASELINE = (
+    Path.home() / ".local" / "state" / "sidepulse" / "agent-monitor" / "hermes-compat-baseline.json"
+)
+
+
+def _run(command: list[str], timeout: int = 20) -> tuple[int, str, str]:
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return 127, "", f"command not found: {command[0]}"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timed out: {' '.join(command)}"
+    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
+
+
+def _json_load(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def discover_plugin_yaml() -> Path | None:
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[1] / "plugin.yaml",
+        Path.home() / ".hermes" / "plugins" / PLUGIN_NAME / "plugin.yaml",
+        _home() / "plugins" / PLUGIN_NAME / "plugin.yaml",
+    ]
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def hooks_from_plugin_yaml(path: Path | None) -> list[str]:
+    if path is None or not path.is_file():
+        return list(REQUIRED_HOOKS)
+    hooks: list[str] = []
+    in_hooks = False
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if line.startswith("hooks:"):
+            in_hooks = True
+            continue
+        if in_hooks:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                hooks.append(stripped[2:].strip())
+                continue
+            if stripped and not stripped.startswith("#"):
+                break
+    return hooks or list(REQUIRED_HOOKS)
+
+
+def hermes_version() -> dict[str, Any]:
+    code, out, err = _run(["hermes", "--version"])
+    text = "\n".join(part for part in (out, err) if part)
+    version = ""
+    install_dir = ""
+    for line in text.splitlines():
+        if line.startswith("Hermes Agent "):
+            version = line.replace("Hermes Agent ", "").strip()
+        if line.startswith("Install directory:"):
+            install_dir = line.split(":", 1)[1].strip()
+    return {
+        "ok": code == 0 and bool(version),
+        "version": version,
+        "install_dir": install_dir,
+        "error": "" if code == 0 else (err or out or f"exit {code}"),
+    }
+
+
+def live_valid_hooks(install_dir: str) -> dict[str, Any]:
+    python = Path(install_dir) / ".venv" / "bin" / "python" if install_dir else None
+    if python and python.is_file():
+        code, out, err = _run(
+            [
+                str(python),
+                "-c",
+                "from hermes_cli.plugins import VALID_HOOKS; print('\\n'.join(sorted(VALID_HOOKS)))",
+            ]
+        )
+        hooks = [line.strip() for line in out.splitlines() if line.strip()]
+        return {
+            "ok": code == 0 and bool(hooks),
+            "hooks": hooks,
+            "error": "" if code == 0 and hooks else (err or out or "could not import VALID_HOOKS"),
+        }
+    return {"ok": False, "hooks": [], "error": "Hermes venv python not found"}
+
+
+def plugin_status() -> dict[str, Any]:
+    code, out, err = _run(["hermes", "plugins", "list", "--no-bundled", "--json"])
+    payload = _json_load(out)
+    plugins = payload if isinstance(payload, list) else []
+    match = next(
+        (item for item in plugins if isinstance(item, dict) and item.get("name") == PLUGIN_NAME),
+        None,
+    )
+    return {
+        "ok": code == 0 and match is not None and match.get("status") == "enabled",
+        "plugin": match,
+        "error": ""
+        if code == 0 and match is not None
+        else (err or out or f"{PLUGIN_NAME} not listed"),
+    }
+
+
+def socket_status() -> dict[str, Any]:
+    xdg = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "state"
+    path = base / "sidepulse" / "agent-monitor" / "events.sock"
+    exists = path.exists()
+    connected = False
+    if exists:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(0.2)
+        try:
+            client.connect(str(path))
+            connected = True
+        except OSError:
+            connected = False
+        finally:
+            client.close()
+    return {
+        "ok": exists and connected,
+        "path": str(path),
+        "exists": exists,
+        "connected": connected,
+        "error": "" if exists and connected else "status-bar socket is not accepting connections",
+    }
+
+
+def sidepulse_cli_status() -> dict[str, Any]:
+    reports: dict[str, Any] = {}
+    all_ok = True
+    for mode in ("working", "ask", "done"):
+        code, out, err = _run(
+            ["hermes", "sidepulse", "test", "--mode", mode, "--json"],
+            timeout=25,
+        )
+        payload = _json_load(out) if code == 0 else None
+        ok = bool(
+            payload
+            and payload.get("mode")
+            and payload.get("logged") is True
+        )
+        reports[mode] = {
+            "ok": ok,
+            "exit_code": code,
+            "report": payload,
+            "error": "" if ok else (err or out or f"test --mode {mode} failed"),
+        }
+        all_ok = all_ok and ok
+    return {"ok": all_ok, "modes": reports}
+
+
+def compare_hooks(required: list[str], live: list[str]) -> dict[str, Any]:
+    required_set = set(required)
+    live_set = set(live)
+    missing = sorted(required_set - live_set)
+    extra = sorted(live_set - required_set)
+    return {
+        "ok": not missing,
+        "required": required,
+        "live": sorted(live_set),
+        "missing": missing,
+        "extra": extra,
+    }
+
+
+def load_baseline(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = _json_load(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else None
+
+
+def write_baseline(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "saved_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hermes_version": report["hermes"]["version"],
+        "hooks": report["hooks"]["live"],
+        "plugin": report["plugin"]["plugin"],
+    }
+    path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_report(*, baseline_path: Path) -> dict[str, Any]:
+    plugin_yaml = discover_plugin_yaml()
+    required = hooks_from_plugin_yaml(plugin_yaml)
+    hermes = hermes_version()
+    hooks_live = live_valid_hooks(hermes.get("install_dir") or "")
+    hooks = compare_hooks(required, hooks_live.get("hooks") or [])
+    if not hooks_live.get("ok"):
+        hooks["ok"] = False
+        hooks["error"] = hooks_live.get("error")
+    plugin = plugin_status()
+    sock = socket_status()
+    tests = sidepulse_cli_status()
+    baseline = load_baseline(baseline_path)
+    drift: dict[str, Any] = {"ok": True, "version_changed": False, "hooks_removed": [], "hooks_added": []}
+    if baseline:
+        previous_hooks = set(baseline.get("hooks") or [])
+        current_hooks = set(hooks.get("live") or [])
+        drift["version_changed"] = bool(
+            baseline.get("hermes_version") and baseline.get("hermes_version") != hermes.get("version")
+        )
+        drift["hooks_removed"] = sorted(previous_hooks - current_hooks)
+        drift["hooks_added"] = sorted(current_hooks - previous_hooks)
+        if any(name in REQUIRED_HOOKS for name in drift["hooks_removed"]):
+            drift["ok"] = False
+
+    checks = {
+        "hermes": hermes["ok"],
+        "hooks": hooks["ok"],
+        "plugin": plugin["ok"],
+        "socket": sock["ok"],
+        "synthetic_events": tests["ok"],
+        "baseline_drift": drift["ok"],
+    }
+    return {
+        "ok": all(checks.values()),
+        "checked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "plugin_yaml": str(plugin_yaml) if plugin_yaml else "",
+        "checks": checks,
+        "hermes": hermes,
+        "hooks": hooks,
+        "plugin": plugin,
+        "socket": sock,
+        "synthetic_events": tests,
+        "baseline": {"path": str(baseline_path), "previous": baseline, "drift": drift},
+    }
+
+
+def print_human(report: dict[str, Any]) -> None:
+    status = "OK" if report["ok"] else "NEEDS FIX"
+    print(f"SidePulse Hermes compatibility: {status}")
+    print(f"  Hermes: {report['hermes'].get('version') or report['hermes'].get('error')}")
+    print(f"  plugin: {((report['plugin'].get('plugin') or {}).get('status') or 'missing')}")
+    print(f"  socket: {'up' if report['socket']['ok'] else 'down'} ({report['socket']['path']})")
+    missing = report["hooks"].get("missing") or []
+    if missing:
+        print(f"  missing hooks: {', '.join(missing)}")
+    else:
+        print(f"  required hooks: {len(report['hooks'].get('required') or REQUIRED_HOOKS)} present")
+    for mode, result in (report["synthetic_events"].get("modes") or {}).items():
+        mark = "ok" if result.get("ok") else "FAIL"
+        delivered = ((result.get("report") or {}).get("delivered"))
+        print(f"  test {mode}: {mark} (socket={'delivered' if delivered else 'not delivered'})")
+    drift = report["baseline"]["drift"]
+    previous = report["baseline"]["previous"]
+    if previous and drift.get("version_changed"):
+        print(
+            f"  Hermes version changed: {previous.get('hermes_version')} -> {report['hermes'].get('version')}"
+        )
+    if drift.get("hooks_removed"):
+        print(f"  hooks removed since last baseline: {', '.join(drift['hooks_removed'])}")
+    if not report["ok"]:
+        print("\nFix the failing checks above before trusting SidePulse after this Hermes update.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print the full report as JSON")
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE,
+        help="Baseline file used to detect hook/version drift",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Write the current Hermes version and hook set as the new baseline",
+    )
+    args = parser.parse_args(argv)
+    report = build_report(baseline_path=args.baseline)
+    if args.update_baseline and report["hooks"].get("live"):
+        write_baseline(args.baseline, report)
+        report["baseline"]["updated"] = True
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_human(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sidepulse/battery.py
+++ b/src/sidepulse/battery.py
@@ -27,6 +27,24 @@ BATTERY_HIGH_GREEN = "#00FF66"
 BATTERY_CHARGING_MINT = "#80FFC8"
 BATTERY_OFF = "#000000"
 DEFAULT_POWER_CHANGE_PREVIEW_SECONDS = 7.0
+POWER_PREVIEW_RETRIGGER_SECONDS = 30.0
+
+
+def should_arm_battery_power_preview(
+    previous_plugged: bool | None,
+    current_plugged: bool,
+    *,
+    now: float,
+    last_armed_at: float | None,
+    retrigger_seconds: float = POWER_PREVIEW_RETRIGGER_SECONDS,
+) -> bool:
+    """Ignore the first reading and rapid plugged/unplugged flaps."""
+
+    if previous_plugged is None or previous_plugged == current_plugged:
+        return False
+    if last_armed_at is None:
+        return True
+    return now - last_armed_at >= retrigger_seconds
 
 
 @dataclass(frozen=True)

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -37,6 +37,7 @@ COMPLETED_VISIBLE_SECONDS = 12.0
 IDLE_VISIBLE_SECONDS = 0.0
 POST_TOOL_WORKING_VISIBLE_SECONDS = 2 * 60.0
 PERMISSION_ASK_DEBOUNCE_SECONDS = 2.0
+SESSION_COMPLETION_EVENTS = frozenset({"Stop", "SessionEnd", "SessionFinalize"})
 
 
 @dataclass(frozen=True)
@@ -413,6 +414,13 @@ class LiveAgentMonitor:
             if status is None:
                 return
 
+            if (
+                record.session_id
+                and record.event_name in SESSION_COMPLETION_EVENTS
+                and status.mode == AgentMode.COMPLETED
+            ):
+                self.clear_session_statuses(record)
+
             track_pending_permissions(record, self.pending_permissions_by_key)
             previous = self.statuses_by_key.get(status.agent_id)
             if should_ignore_status_transition(
@@ -423,6 +431,40 @@ class LiveAgentMonitor:
                 return
             self.statuses_by_key[status.agent_id] = status
             self.write_latest_state()
+
+    def clear_session_statuses(self, record: HookEvent) -> None:
+        """Remove prior agent identities completed by the same logical session."""
+        session_id = record.session_id
+        if not session_id:
+            return
+
+        identity_prefix = f"{record.identity_prefix}:"
+        removed_status_keys = {
+            key
+            for key, status in self.statuses_by_key.items()
+            if status.provider == record.provider
+            and status.session_id == session_id
+            and status.agent_id.startswith(identity_prefix)
+        }
+        if not removed_status_keys:
+            return
+
+        self.statuses_by_key = {
+            key: status
+            for key, status in self.statuses_by_key.items()
+            if key not in removed_status_keys
+        }
+        self.metadata_by_status = {
+            key: metadata
+            for key, metadata in self.metadata_by_status.items()
+            if key not in removed_status_keys
+        }
+        self.pending_permissions_by_key = {
+            key: pending
+            for key, pending in self.pending_permissions_by_key.items()
+            if key not in removed_status_keys
+        }
+        self.metadata_by_session.pop(record.session_key, None)
 
     def prepare_replay_records(
         self,

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -38,6 +38,9 @@ IDLE_VISIBLE_SECONDS = 0.0
 POST_TOOL_WORKING_VISIBLE_SECONDS = 2 * 60.0
 PERMISSION_ASK_DEBOUNCE_SECONDS = 2.0
 SESSION_COMPLETION_EVENTS = frozenset({"Stop", "SessionEnd", "SessionFinalize"})
+SESSION_IDENTITY_RECONCILIATION_EVENTS = frozenset(
+    {"SessionStart", "SessionActivate", *SESSION_COMPLETION_EVENTS}
+)
 
 
 @dataclass(frozen=True)
@@ -414,10 +417,24 @@ class LiveAgentMonitor:
             if status is None:
                 return
 
+            idle_boundary = (
+                record.event_name in {"SessionStart", "SessionActivate"}
+                and status.mode == AgentMode.IDLE_READY
+            )
+            same_session_prefix = f"{record.identity_prefix}:"
+            has_completed_status = bool(record.session_id) and any(
+                existing.provider == record.provider
+                and existing.session_id == record.session_id
+                and existing.agent_id.startswith(same_session_prefix)
+                and existing.mode == AgentMode.COMPLETED
+                for existing in self.statuses_by_key.values()
+            )
+            if idle_boundary and has_completed_status:
+                return
+
             if (
                 record.session_id
-                and record.event_name in SESSION_COMPLETION_EVENTS
-                and status.mode == AgentMode.COMPLETED
+                and record.event_name in SESSION_IDENTITY_RECONCILIATION_EVENTS
             ):
                 self.clear_session_statuses(record)
 

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import threading
 import time
@@ -32,9 +33,10 @@ CLAUDE_TRANSCRIPT_MAX_LINES = 500
 TRANSCRIPT_FILE_LIST_CACHE_SECONDS = 5.0
 CLAUDE_TRANSCRIPT_MTIME_HEARTBEAT_SKEW_SECONDS = 30.0
 CODEX_SESSION_INDEX_MAX_LINES = 5000
-COMPLETED_VISIBLE_SECONDS = 20 * 60.0
+COMPLETED_VISIBLE_SECONDS = 12.0
 IDLE_VISIBLE_SECONDS = 0.0
 POST_TOOL_WORKING_VISIBLE_SECONDS = 2 * 60.0
+PERMISSION_ASK_DEBOUNCE_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
@@ -422,6 +424,109 @@ class LiveAgentMonitor:
             self.statuses_by_key[status.agent_id] = status
             self.write_latest_state()
 
+    def prepare_replay_records(
+        self,
+        provider: str,
+        records: tuple[HookEvent, ...],
+    ) -> tuple[HookEvent, ...]:
+        """Reconcile replayed identities without discarding newer live state."""
+
+        with self.lock:
+            protected_status_keys: set[str] = set()
+            protected_current_status_keys: set[str] = set()
+            for current_key, status in self.statuses_by_key.items():
+                if status.provider != provider:
+                    continue
+                matching = tuple(
+                    record
+                    for record in records
+                    if record.status_key == status.agent_id
+                    or (
+                        record.session_id is not None
+                        and record.session_id == status.session_id
+                    )
+                )
+                if matching and status.updated_at > max(
+                    record.logged_at for record in matching
+                ):
+                    protected_current_status_keys.add(current_key)
+                    protected_status_keys.update(
+                        record.status_key for record in matching
+                    )
+
+            replay_records = tuple(
+                record
+                for record in records
+                if record.status_key not in protected_status_keys
+            )
+            represented_session_ids = {
+                record.session_id
+                for record in records
+                if record.session_id is not None
+            }
+            represented_status_keys = {
+                record.status_key for record in records
+            }
+            removed_status_keys = {
+                key
+                for key, status in self.statuses_by_key.items()
+                if status.provider == provider
+                and key not in protected_current_status_keys
+                and (
+                    key in represented_status_keys
+                    or status.session_id in represented_session_ids
+                )
+            }
+            if not removed_status_keys:
+                return replay_records
+
+            removed_session_ids = {
+                status.session_id
+                for key, status in self.statuses_by_key.items()
+                if key in removed_status_keys and status.session_id is not None
+            }
+            self.statuses_by_key = {
+                key: status
+                for key, status in self.statuses_by_key.items()
+                if key not in removed_status_keys
+            }
+            self.metadata_by_session = {
+                key: metadata
+                for key, metadata in self.metadata_by_session.items()
+                if not (
+                    key.startswith(f"{provider}:")
+                    and any(
+                        key.endswith(f":session:{session_id}")
+                        for session_id in removed_session_ids
+                    )
+                )
+            }
+            self.metadata_by_status = {
+                key: metadata
+                for key, metadata in self.metadata_by_status.items()
+                if key not in removed_status_keys
+            }
+            self.pending_permissions_by_key = {
+                key: pending
+                for key, pending in self.pending_permissions_by_key.items()
+                if key not in removed_status_keys
+            }
+            return replay_records
+
+    def ingest_replay_records(
+        self,
+        provider: str,
+        records: tuple[HookEvent, ...],
+    ) -> int:
+        """Reconcile and ingest one replay batch without interleaving live events."""
+
+        with self.lock:
+            replay_records = self.prepare_replay_records(provider, records)
+            for record in replay_records:
+                self.ingest_record(record)
+            self.write_latest_state()
+            return len(replay_records)
+
     def snapshot(self, include_stale: bool = False) -> MonitorSnapshot:
         now = datetime.now(timezone.utc)
         with self.lock:
@@ -466,10 +571,28 @@ class LiveAgentMonitor:
             ],
         }
         try:
-            self.latest_state_path.parent.mkdir(parents=True, exist_ok=True)
+            self.latest_state_path.parent.mkdir(
+                parents=True,
+                exist_ok=True,
+                mode=0o700,
+            )
+            self.latest_state_path.parent.chmod(0o700)
             temp_path = self.latest_state_path.with_suffix(".json.tmp")
-            temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            descriptor = os.open(
+                temp_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            try:
+                os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                    descriptor = -1
+                    handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
             temp_path.replace(self.latest_state_path)
+            self.latest_state_path.chmod(0o600)
         except OSError:
             pass
 
@@ -957,7 +1080,7 @@ def metadata_for_record(
     session_metadata = None
     if record.session_id:
         session_metadata = metadata_by_session.setdefault(
-            f"{record.provider}:session:{record.session_id}",
+            record.session_key,
             StatusMetadata(),
         )
         update_metadata(session_metadata, record)
@@ -990,15 +1113,30 @@ def update_metadata(metadata: StatusMetadata, record: HookEvent) -> None:
 def is_provider_session_title(record: HookEvent, title: str) -> bool:
     if record.provider == "codex":
         return title == codex_session_title(record.session_id)
+    if record.provider == "hermes":
+        session_title = record.raw.get("session_title")
+        return isinstance(session_title, str) and title == session_title.strip()
     return False
 
 
 def status_from_event(record: HookEvent, metadata: StatusMetadata | None = None) -> AgentStatus | None:
+    if record.provider == "hermes" and (
+        not record.session_id
+        or (
+            not record.hermes_profile
+            and record.raw.get("_hermes_session_metadata_scoped") is not True
+        )
+    ):
+        return None
+
     mode = mode_for_event(record)
     if mode is None:
         return None
 
-    metadata = metadata or StatusMetadata(cwd=record.cwd)
+    metadata = metadata or StatusMetadata(
+        cwd=record.cwd,
+        title=title_from_event(record),
+    )
     if should_ignore_record(record, metadata):
         return None
 
@@ -1281,10 +1419,24 @@ def status_for_snapshot(
     if (
         status.mode == AgentMode.WORKING
         and status.event_name == "PostToolUse"
+        and status.provider != "hermes"
         and post_tool_working_visible_seconds >= 0
         and status.age_seconds(now) > post_tool_working_visible_seconds
     ):
         return _replace_mode(status, AgentMode.COMPLETED)
+    if (
+        status.provider == "hermes"
+        and status.mode == AgentMode.WAITING_FOR_INPUT
+        and status.event_name == "PermissionRequest"
+        and status.age_seconds(now) < PERMISSION_ASK_DEBOUNCE_SECONDS
+    ):
+        return _replace_mode(status, AgentMode.WORKING)
+    if (
+        status.provider == "hermes"
+        and status.mode == AgentMode.BLOCKED_ERROR
+        and status.event_name == "PostToolUseFailure"
+    ):
+        return _replace_mode(status, AgentMode.WORKING)
     return status
 
 
@@ -1374,7 +1526,13 @@ def should_ignore_status_transition(
     if (
         previous is not None
         and previous.mode == AgentMode.COMPLETED
-        and current.event_name == "Notification"
+        and (
+            current.event_name == "Notification"
+            or (
+                current.event_name in {"SessionActivate", "SessionStart"}
+                and current.mode == AgentMode.IDLE_READY
+            )
+        )
     ):
         return True
 
@@ -1436,6 +1594,46 @@ def read_recent_lines(path: Path, max_lines: int) -> list[str]:
     return lines[-max_lines:]
 
 
+def replay_recent_debug_logs(
+    monitor: LiveAgentMonitor,
+    *,
+    providers: tuple[str, ...] = ("codex", "claude", "grok", "hermes"),
+    max_lines: int = 500,
+    detect_log_path_fn: Callable[[str], Path] = detect_log_path,
+    error_handler: Callable[[str], None] | None = None,
+) -> int:
+    replayed = 0
+    for provider in providers:
+        try:
+            path = detect_log_path_fn(provider)
+            lines = read_recent_lines(path, max_lines) if path.exists() else []
+            records = tuple(
+                record
+                for line in lines
+                if (record := parse_log_line(provider, line)) is not None
+            )
+        except Exception as exc:
+            if error_handler is not None:
+                error_handler(f"startup_replay_error provider={provider} error={exc}")
+            continue
+
+        if not records:
+            continue
+
+        # Hermes session enrichment can change the logical agent key as its
+        # database metadata becomes available. Reconcile only sessions that are
+        # represented by replay and never replace newer socket-delivered state.
+        if provider == "hermes":
+            replayed += monitor.ingest_replay_records(provider, records)
+            continue
+
+        for record in records:
+            monitor.ingest_record(record)
+            replayed += 1
+
+    return replayed
+
+
 def _replace_stale(status: AgentStatus, stale: bool) -> AgentStatus:
     if status.stale == stale:
         return status
@@ -1475,6 +1673,10 @@ def _replace_mode(status: AgentStatus, mode: AgentMode) -> AgentStatus:
 
 
 def title_from_event(record: HookEvent) -> str | None:
+    explicit_title = record.raw.get("session_title")
+    if isinstance(explicit_title, str) and explicit_title.strip():
+        return explicit_title.strip()
+
     if record.provider == "codex":
         title = codex_session_title(record.session_id)
         if title:

--- a/src/sidepulse/led_status.py
+++ b/src/sidepulse/led_status.py
@@ -13,6 +13,14 @@ from .device_writer import (
 )
 from .models import AgentMode
 
+ACTIVE_AGENT_MODES = {
+    AgentMode.WORKING,
+    AgentMode.TOOL_RUNNING,
+    AgentMode.WAITING_FOR_INPUT,
+    AgentMode.LONG_TASK_PROGRESS,
+    AgentMode.BLOCKED_ERROR,
+}
+
 
 class LedDisplayState(str, Enum):
     IDLE = "idle"
@@ -64,6 +72,24 @@ def display_state_for_mode(mode: AgentMode) -> LedDisplayState:
     if mode == AgentMode.COMPLETED:
         return LedDisplayState.DONE
     return LedDisplayState.IDLE
+
+
+def resolve_led_display_kind(
+    configured_display: str,
+    *,
+    battery_preview_active: bool,
+    agent_mode: AgentMode,
+) -> str:
+    """Choose agent vs battery LEDs without letting previews hide live work."""
+
+    display = str(configured_display or "agent").strip().lower()
+    if display == "custom":
+        return "custom"
+    if display == "battery":
+        return "battery"
+    if battery_preview_active and agent_mode not in ACTIVE_AGENT_MODES:
+        return "battery"
+    return "agent"
 
 
 def program_for_display_state(

--- a/src/sidepulse/models.py
+++ b/src/sidepulse/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -54,14 +55,31 @@ class HookEvent:
     tool_name: str | None = None
     message: str | None = None
     origin: str | None = None
+    hermes_profile: str | None = None
+
+    @property
+    def identity_prefix(self) -> str:
+        if self.provider != "hermes":
+            return self.provider
+        profile = str(self.hermes_profile or "").strip()
+        if not profile:
+            return f"{self.provider}:profile:missing"
+        profile_digest = hashlib.sha256(profile.encode("utf-8")).hexdigest()[:12]
+        return f"{self.provider}:profile:{profile_digest}"
+
+    @property
+    def session_key(self) -> str:
+        if self.session_id:
+            return f"{self.identity_prefix}:session:{self.session_id}"
+        return f"{self.identity_prefix}:session:unknown"
 
     @property
     def status_key(self) -> str:
         if self.agent_id:
-            return f"{self.provider}:agent:{self.agent_id}"
+            return f"{self.identity_prefix}:agent:{self.agent_id}"
         if self.session_id:
-            return f"{self.provider}:session:{self.session_id}"
-        return f"{self.provider}:unknown"
+            return self.session_key
+        return f"{self.identity_prefix}:unknown"
 
 
 @dataclass(frozen=True)

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -62,7 +62,10 @@ GROK_EVENTS = (
 )
 
 HOOK_PROVIDERS = ("codex", "claude", "grok")
-KNOWN_EVENTS = tuple(dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS))
+HERMES_EVENTS = ("SessionActivate",)
+KNOWN_EVENTS = tuple(
+    dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS + HERMES_EVENTS)
+)
 
 
 @dataclass(frozen=True)

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -66,7 +66,7 @@ GROK_EVENTS = (
 )
 
 HOOK_PROVIDERS = ("codex", "claude", "grok")
-HERMES_EVENTS = ("SessionActivate",)
+HERMES_EVENTS = ("SessionActivate", "SessionFinalize")
 KNOWN_EVENTS = tuple(
     dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS + HERMES_EVENTS)
 )

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import shlex
+import sqlite3
+import time
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -66,6 +70,12 @@ HERMES_EVENTS = ("SessionActivate",)
 KNOWN_EVENTS = tuple(
     dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS + HERMES_EVENTS)
 )
+
+_HERMES_SESSION_CACHE_TTL_SECONDS = 2.0
+_HERMES_SESSION_CACHE: dict[
+    tuple[str, str], tuple[float, tuple[str, str | None] | None]
+] = {}
+_HERMES_PROFILE_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 
 
 @dataclass(frozen=True)
@@ -291,6 +301,8 @@ def parse_log_line(provider: str, line: str) -> HookEvent | None:
         return None
 
     normalized_raw = normalize_event_payload(raw, event_name, logged_at)
+    if provider == "hermes":
+        enrich_hermes_session(normalized_raw)
 
     return HookEvent(
         provider=provider,
@@ -304,7 +316,244 @@ def parse_log_line(provider: str, line: str) -> HookEvent | None:
         tool_name=_first_string(normalized_raw, "tool_name", "toolName"),
         message=_first_string(normalized_raw, "message", "last_assistant_message", "lastAssistantMessage"),
         origin=origin_label_from_payload(provider, normalized_raw),
+        hermes_profile=_first_string(normalized_raw, "hermes_profile"),
     )
+
+
+def enrich_hermes_session(raw: dict[str, Any]) -> None:
+    session_id = _first_string(raw, "session_id", "sessionId")
+    if not session_id:
+        return
+
+    profile_name = _first_string(raw, "hermes_profile")
+    if not profile_name and not os.environ.get("SIDEPULSE_HERMES_STATE_DB"):
+        # An unscoped event cannot be attributed safely when multiple Hermes
+        # profiles share the same durable session identifiers. An explicitly
+        # configured database is the caller's deliberate scope.
+        return
+    metadata = hermes_session_metadata(session_id, profile_name=profile_name)
+    if metadata is None:
+        return
+
+    root_session_id, title = metadata
+    if not profile_name:
+        raw["_hermes_session_metadata_scoped"] = True
+    current_agent_id = _first_string(raw, "agent_id", "agentId") or "hermes"
+    agent_prefix = current_agent_id.rsplit(":", 1)[0]
+    root_digest = hashlib.sha256(root_session_id.encode("utf-8")).hexdigest()[:12]
+    raw["agent_id"] = f"{agent_prefix}:{root_digest}"
+    if title:
+        raw["session_title"] = title
+
+
+def hermes_session_metadata(
+    session_id: str,
+    *,
+    profile_name: str | None = None,
+) -> tuple[str, str | None] | None:
+    now = time.monotonic()
+    matches: list[tuple[str, str | None]] = []
+    for state_db in hermes_state_db_paths(profile_name=profile_name):
+        cache_key = (str(state_db), session_id)
+        cached = _HERMES_SESSION_CACHE.get(cache_key)
+        if cached and now - cached[0] < _HERMES_SESSION_CACHE_TTL_SECONDS:
+            if cached[1] is not None:
+                matches.append(cached[1])
+            continue
+
+        metadata = hermes_session_metadata_from_db(state_db, session_id)
+        _HERMES_SESSION_CACHE[cache_key] = (now, metadata)
+        if metadata is not None:
+            matches.append(metadata)
+
+    # A profile selector narrows discovery to one database. Profile-less
+    # lookups are only reachable here for an explicitly configured database;
+    # automatic multi-profile discovery is rejected by enrich_hermes_session.
+    if profile_name:
+        return matches[0] if matches else None
+    return matches[0] if len(matches) == 1 else None
+
+
+def hermes_state_db_paths(*, profile_name: str | None = None) -> tuple[Path, ...]:
+    configured = os.environ.get("SIDEPULSE_HERMES_STATE_DB")
+    configured_db = Path(configured).expanduser() if configured else None
+
+    configured_home = os.environ.get("HERMES_HOME")
+    active_home = (
+        Path(configured_home).expanduser()
+        if configured_home
+        else Path.home() / ".hermes"
+    )
+    root_home = (
+        active_home.parent.parent
+        if active_home.parent.name == "profiles"
+        else active_home
+    )
+
+    if profile_name:
+        normalized_profile = profile_name.strip()
+        normalized_casefold = normalized_profile.casefold()
+        if normalized_casefold == "custom":
+            selected_db = active_home / "state.db"
+        elif normalized_casefold == "default":
+            selected_db = root_home / "state.db"
+        elif not _HERMES_PROFILE_TOKEN.fullmatch(normalized_profile):
+            return ()
+        elif (
+            active_home.parent.name == "profiles"
+            and active_home.name == normalized_profile
+        ):
+            selected_db = active_home / "state.db"
+        else:
+            selected_db = root_home / "profiles" / normalized_profile / "state.db"
+
+        if configured_db is not None:
+            if configured_db.resolve(strict=False) != selected_db.resolve(strict=False):
+                return ()
+            return (configured_db,)
+        return (selected_db,)
+
+    if configured_db is not None:
+        return (configured_db,)
+
+    candidates: list[Path] = [active_home / "state.db"]
+    candidates.append(root_home / "state.db")
+    candidates.extend(sorted((root_home / "profiles").glob("*/state.db")))
+    return _dedupe_paths(candidates)
+
+
+def _hermes_session_is_explicit_fork(session: dict[str, Any]) -> bool:
+    if session.get("source") == "tool":
+        return True
+    raw_config = session.get("model_config")
+    if not raw_config:
+        return False
+    try:
+        config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    except (TypeError, json.JSONDecodeError):
+        return False
+    if not isinstance(config, dict):
+        return False
+    parent_id = session.get("parent_session_id")
+    return bool(
+        parent_id
+        and (
+            config.get("_branched_from") == parent_id
+            or config.get("_delegate_from") == parent_id
+            or config.get("_reset_from") == parent_id
+        )
+    )
+
+
+def hermes_session_metadata_from_db(
+    state_db: Path,
+    session_id: str,
+) -> tuple[str, str | None] | None:
+    if not state_db.is_file():
+        return None
+
+    try:
+        database_uri = f"file:{state_db.resolve()}?mode=ro"
+        with closing(sqlite3.connect(database_uri, uri=True, timeout=0.25)) as connection:
+            connection.row_factory = sqlite3.Row
+            columns = {
+                str(row[1])
+                for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
+            }
+            required = {"id", "parent_session_id", "title", "started_at"}
+            if not required.issubset(columns):
+                return None
+
+            selected_columns = [
+                "id",
+                "parent_session_id",
+                "title",
+                "started_at",
+            ]
+            selected_columns.extend(
+                column
+                for column in ("end_reason", "source", "model_config")
+                if column in columns
+            )
+            projection = ", ".join(selected_columns)
+
+            def load_session(candidate_id: str) -> dict[str, Any] | None:
+                row = connection.execute(
+                    f"SELECT {projection} FROM sessions WHERE id = ?",
+                    (candidate_id,),
+                ).fetchone()
+                return dict(row) if row is not None else None
+
+            requested = load_session(session_id)
+            if requested is None:
+                return None
+
+            # Compression cannot be proven against legacy/incomplete schemas.
+            # Keep the requested session independent rather than merging it with
+            # branches, delegates, or tool children based on parent_id alone.
+            if "end_reason" not in columns:
+                title = str(requested.get("title") or "").strip() or None
+                return str(requested["id"]), title
+
+            root = requested
+            anchored_child_by_parent: dict[str, dict[str, Any]] = {}
+            seen = {str(root["id"])}
+            for _ in range(128):
+                parent_id = str(root.get("parent_session_id") or "")
+                if (
+                    not parent_id
+                    or parent_id in seen
+                    or _hermes_session_is_explicit_fork(root)
+                ):
+                    break
+                parent = load_session(parent_id)
+                if parent is None or parent.get("end_reason") != "compression":
+                    break
+                anchored_child_by_parent[parent_id] = root
+                root = parent
+                seen.add(parent_id)
+
+            lineage = [root]
+            current = root
+            seen = {str(root["id"])}
+            for _ in range(128):
+                if current.get("end_reason") != "compression":
+                    break
+                current_id = str(current["id"])
+                next_child = anchored_child_by_parent.get(current_id)
+                if next_child is None:
+                    rows = connection.execute(
+                        f"SELECT {projection} FROM sessions "
+                        "WHERE parent_session_id = ? "
+                        "ORDER BY started_at DESC, id DESC",
+                        (current_id,),
+                    ).fetchall()
+                    for row in rows:
+                        candidate = dict(row)
+                        if not _hermes_session_is_explicit_fork(candidate):
+                            next_child = candidate
+                            break
+                if next_child is None or str(next_child["id"]) in seen:
+                    break
+                lineage.append(next_child)
+                current = next_child
+                seen.add(str(current["id"]))
+
+            titled = [
+                row
+                for row in lineage
+                if isinstance(row.get("title"), str) and row["title"].strip()
+            ]
+            latest_title = max(
+                titled,
+                key=lambda row: (str(row.get("started_at") or ""), str(row["id"])),
+                default=None,
+            )
+    except (OSError, sqlite3.Error):
+        return None
+
+    title = str(latest_title["title"]).strip() if latest_title is not None else None
+    return str(root["id"]), title or None
 
 
 def infer_provider_from_payload(provider: str, raw: dict[str, Any]) -> str:

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -66,6 +66,7 @@ from .battery import (
     format_watts,
     program_for_battery,
     read_battery_snapshot,
+    should_arm_battery_power_preview,
 )
 from .audit import (
     append_status_history_record,
@@ -76,7 +77,12 @@ from .audit import (
     read_status_history_records,
     status_history_record,
 )
-from .collector import LiveAgentMonitor, SourceSpec, read_recent_lines
+from .collector import (
+    COMPLETED_VISIBLE_SECONDS,
+    LiveAgentMonitor,
+    SourceSpec,
+    replay_recent_debug_logs as replay_recent_debug_log_records,
+)
 from .device_writer import (
     DEFAULT_FILE_NAME,
     MOUNT_ROOT,
@@ -106,6 +112,7 @@ from .led_status import (
     normalize_brightness,
     normalized_device_name,
     program_for_display_state,
+    resolve_led_display_kind,
     write_mode_to_leds,
     display_state_for_mode,
 )
@@ -341,25 +348,16 @@ def format_percent_value(value: float | int) -> str:
 def replay_recent_debug_logs(
     monitor: LiveAgentMonitor,
     *,
-    providers: tuple[str, ...] = ("codex", "claude", "grok"),
+    providers: tuple[str, ...] = ("codex", "claude", "grok", "hermes"),
     max_lines: int = STATUS_BAR_STARTUP_REPLAY_LINES,
 ) -> int:
-    replayed = 0
-    for provider in providers:
-        try:
-            path = detect_log_path(provider)
-            lines = read_recent_lines(path, max_lines) if path.exists() else []
-        except Exception as exc:
-            log_status_bar(f"startup_replay {provider} error: {exc}")
-            continue
-
-        for line in lines:
-            record = parse_log_line(provider, line)
-            if record is None:
-                continue
-            monitor.ingest_record(record)
-            replayed += 1
-    return replayed
+    return replay_recent_debug_log_records(
+        monitor,
+        providers=providers,
+        max_lines=max_lines,
+        detect_log_path_fn=detect_log_path,
+        error_handler=log_status_bar,
+    )
 
 
 class StatusBarController(NSObject):
@@ -386,7 +384,9 @@ class StatusBarController(NSObject):
         self.last_battery_error = None
         self.last_power_connected = None
         self.battery_preview_until = 0.0
+        self.last_battery_preview_armed_at = None
         self.current_state = STATE_IDLE
+        self.completed_idle_timer = None
         self.led_controller = AgentLedController()
         self.battery_led_controller = BatteryLedController()
         self.agent_led_controllers_by_device = {}
@@ -500,7 +500,10 @@ class StatusBarController(NSObject):
         self.sync_leds(
             snapshot.aggregate.mode,
             battery_snapshot,
-            self.active_led_display_kind(battery_snapshot),
+            self.active_led_display_kind(
+                battery_snapshot,
+                snapshot.aggregate.mode,
+            ),
         )
         self.status_item.setMenu_(build_menu(snapshot, state, self))
 
@@ -790,6 +793,11 @@ class StatusBarController(NSObject):
     def set_status(self, state: StatusBarState) -> None:
         previous = self.current_state
         self.current_state = state
+        if previous != state:
+            if state == STATE_DONE:
+                self.schedule_completed_idle_refresh()
+            else:
+                self.cancel_completed_idle_refresh()
         if self.status_item is None:
             return
         button = self.status_item.button()
@@ -800,6 +808,33 @@ class StatusBarController(NSObject):
         button.setToolTip_(f"SidePulse Agent Monitor: {state.label}")
         if previous != state:
             log_status_bar(f"state={state.label}")
+
+    def cancel_completed_idle_refresh(self) -> None:
+        timer = getattr(self, "completed_idle_timer", None)
+        if timer is not None:
+            try:
+                timer.invalidate()
+            except Exception:
+                pass
+        self.completed_idle_timer = None
+
+    def schedule_completed_idle_refresh(self) -> None:
+        self.cancel_completed_idle_refresh()
+        self.completed_idle_timer = (
+            NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                COMPLETED_VISIBLE_SECONDS + 0.05,
+                self,
+                "refreshAfterCompleted:",
+                None,
+                False,
+            )
+        )
+
+    @objc.IBAction
+    def refreshAfterCompleted_(self, _sender):
+        self.completed_idle_timer = None
+        if self.current_state == STATE_DONE:
+            self.refresh_(None)
 
     def build_monitor(self) -> LiveAgentMonitor:
         socket_path = default_event_socket_path()
@@ -1372,7 +1407,10 @@ class StatusBarController(NSObject):
             self.sync_leds(
                 self.last_snapshot.aggregate.mode,
                 self.last_battery_snapshot,
-                self.active_led_display_kind(self.last_battery_snapshot),
+                self.active_led_display_kind(
+                    self.last_battery_snapshot,
+                    self.last_snapshot.aggregate.mode,
+                ),
             )
 
     def set_virtual_status_device(self, enabled: bool) -> None:
@@ -1608,15 +1646,22 @@ class StatusBarController(NSObject):
 
     def update_battery_power_preview(self, snapshot: BatterySnapshot) -> None:
         plugged = snapshot.is_plugged
-        if self.last_power_connected is not None and self.last_power_connected != plugged:
-            if self.settings.battery_show_on_power_change:
-                self.battery_preview_until = (
-                    time.monotonic()
-                    + self.settings.battery_power_change_preview_seconds
-                )
-                log_status_bar(
-                    f"battery preview power={'plugged' if plugged else 'unplugged'}"
-                )
+        now = time.monotonic()
+        if (
+            self.settings.battery_show_on_power_change
+            and should_arm_battery_power_preview(
+                self.last_power_connected,
+                plugged,
+                now=now,
+                last_armed_at=self.last_battery_preview_armed_at,
+            )
+        ):
+            self.battery_preview_until = (
+                now + self.settings.battery_power_change_preview_seconds
+            )
+            self.last_battery_preview_armed_at = now
+            state = "plugged" if plugged else "unplugged"
+            log_status_bar(f"battery preview power={state}")
         self.last_power_connected = plugged
 
     def read_mac_sleep_snapshot(self) -> MacSleepSnapshot | None:
@@ -1665,14 +1710,18 @@ class StatusBarController(NSObject):
 
         self.last_status_history_error = None
 
-    def active_led_display_kind(self, snapshot: BatterySnapshot | None) -> str:
-        if self.settings.led_display == LED_DISPLAY_CUSTOM:
-            return LED_DISPLAY_CUSTOM
-        if self.settings.led_display == LED_DISPLAY_BATTERY:
-            return LED_DISPLAY_BATTERY
-        if snapshot is not None and time.monotonic() < self.battery_preview_until:
-            return LED_DISPLAY_BATTERY
-        return LED_DISPLAY_AGENT
+    def active_led_display_kind(
+        self,
+        snapshot: BatterySnapshot | None,
+        agent_mode: AgentMode = AgentMode.IDLE_READY,
+    ) -> str:
+        return resolve_led_display_kind(
+            self.settings.led_display,
+            battery_preview_active=(
+                snapshot is not None and time.monotonic() < self.battery_preview_until
+            ),
+            agent_mode=agent_mode,
+        )
 
     def reset_led_controllers_for_display_change(self) -> None:
         self.led_controller.reset()
@@ -1827,14 +1876,18 @@ class StatusBarController(NSObject):
         self,
         device: StatusBarDevice,
         battery_snapshot: BatterySnapshot | None,
+        agent_mode: AgentMode = AgentMode.IDLE_READY,
     ) -> str:
-        if device.display == LED_DISPLAY_CUSTOM:
-            return LED_DISPLAY_CUSTOM
-        if device.display == LED_DISPLAY_BATTERY:
-            return LED_DISPLAY_BATTERY
-        if battery_snapshot is not None and time.monotonic() < self.battery_preview_until:
-            return LED_DISPLAY_BATTERY
-        return LED_DISPLAY_AGENT
+        if device.display in {LED_DISPLAY_CUSTOM, LED_DISPLAY_BATTERY}:
+            return device.display
+        return resolve_led_display_kind(
+            LED_DISPLAY_AGENT,
+            battery_preview_active=(
+                battery_snapshot is not None
+                and time.monotonic() < self.battery_preview_until
+            ),
+            agent_mode=agent_mode,
+        )
 
     def sync_leds(
         self,
@@ -1879,7 +1932,11 @@ class StatusBarController(NSObject):
         )
         if device is None:
             return
-        display = self.active_led_display_kind_for_device(device, battery_snapshot)
+        display = self.active_led_display_kind_for_device(
+            device,
+            battery_snapshot,
+            mode,
+        )
         if display == LED_DISPLAY_CUSTOM:
             self.virtual_status_device.hide()
             return
@@ -1937,6 +1994,7 @@ class StatusBarController(NSObject):
             device_display_kind = self.active_led_display_kind_for_device(
                 device,
                 battery_snapshot,
+                mode,
             )
             if self.last_led_display_kind_by_device.get(device.device_id) != device_display_kind:
                 self.reset_led_controllers_for_device(device.device_id)
@@ -3807,7 +3865,10 @@ def restore_led_display(target, token_value) -> None:
         target.sync_leds(
             target.last_snapshot.aggregate.mode,
             target.last_battery_snapshot,
-            target.active_led_display_kind(target.last_battery_snapshot),
+            target.active_led_display_kind(
+                target.last_battery_snapshot,
+                target.last_snapshot.aggregate.mode,
+            ),
         )
     else:
         target.refresh_(None)

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -1031,5 +1031,29 @@ class HermesPluginRegistrationTests(unittest.TestCase):
             self.assertEqual(event["sidepulse_mode"], "completed")
 
 
+class HermesCompatScriptTests(unittest.TestCase):
+    def test_compare_hooks_fails_when_required_hook_disappears(self) -> None:
+        script_path = PLUGIN_ROOT / "scripts" / "check_hermes_compat.py"
+        spec = importlib.util.spec_from_file_location("sidepulse_hermes_compat", script_path)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        result = module.compare_hooks(
+            ["pre_llm_call", "post_llm_call", "on_session_activate"],
+            ["pre_llm_call", "post_llm_call"],
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["missing"], ["on_session_activate"])
+
+    def test_plugin_yaml_lists_every_required_hook(self) -> None:
+        script_path = PLUGIN_ROOT / "scripts" / "check_hermes_compat.py"
+        spec = importlib.util.spec_from_file_location("sidepulse_hermes_compat_yaml", script_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        hooks = module.hooks_from_plugin_yaml(PLUGIN_ROOT / "plugin.yaml")
+        self.assertEqual(sorted(hooks), sorted(module.REQUIRED_HOOKS))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -349,7 +349,9 @@ class HermesBridgeTests(unittest.TestCase):
             event_log.write_text(
                 json.dumps(
                     {
+                        "agent_id": bridge._status_agent_id("Hermes", "session-a"),
                         "hook_event_name": "SessionStart",
+                        "integration": "hermes-plugin",
                         "session_id": "session-a",
                         "surface": "desktop",
                     }
@@ -374,7 +376,9 @@ class HermesBridgeTests(unittest.TestCase):
         initial = (
             json.dumps(
                 {
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
                     "hook_event_name": "SessionStart",
+                    "integration": "hermes-plugin",
                     "session_id": "session-a",
                     "surface": "desktop",
                 }
@@ -422,17 +426,23 @@ class HermesBridgeTests(unittest.TestCase):
             event_log = state_dir / "hermes.jsonl"
             records = (
                 {
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
                     "hook_event_name": "SessionStart",
+                    "integration": "hermes-plugin",
                     "session_id": "session-a",
                     "surface": "desktop",
                 },
                 {
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
                     "hook_event_name": "PermissionRequest",
+                    "integration": "hermes-plugin",
                     "session_id": "session-a",
                     "surface": "cli",
                 },
                 {
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
                     "hook_event_name": "PermissionDenied",
+                    "integration": "hermes-plugin",
                     "session_id": "session-a",
                     "surface": "cli",
                 },
@@ -499,6 +509,7 @@ class HermesPluginRegistrationTests(unittest.TestCase):
                 set(ctx.hooks),
                 {
                     "on_session_start",
+                    "on_session_activate",
                     "on_session_reset",
                     "pre_llm_call",
                     "pre_tool_call",
@@ -522,6 +533,129 @@ class HermesPluginRegistrationTests(unittest.TestCase):
             self.assertRegex(event["agent_id"], r"^EDI:[0-9a-f]{12}$")
             self.assertEqual(event["surface"], "desktop")
             self.assertNotIn("private prompt", json.dumps(event))
+
+    def test_session_activation_reasserts_running_wait_state_or_idle(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_tool_call"](
+                session_id="session-ask",
+                platform="desktop",
+                tool_name="clarify",
+            )
+            ctx.hooks["on_session_activate"](
+                session_id="session-ask",
+                platform="desktop",
+                running=True,
+            )
+            ctx.hooks["on_session_activate"](
+                session_id="session-idle",
+                platform="desktop",
+                running=False,
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual(events[-2]["hook_event_name"], "SessionActivate")
+            self.assertEqual(events[-2]["sidepulse_mode"], "waiting_for_input")
+            self.assertEqual(events[-1]["hook_event_name"], "SessionActivate")
+            self.assertEqual(events[-1]["sidepulse_mode"], "idle_ready")
+
+    def test_running_session_activation_defaults_to_working(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["on_session_activate"](
+                session_id="session-working",
+                platform="desktop",
+                running=True,
+            )
+
+            event = json.loads((state_dir / "hermes.jsonl").read_text().strip())
+            self.assertEqual(event["sidepulse_mode"], "working")
+
+    def test_session_activation_recovery_is_scoped_to_agent_provenance(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            shared_config = {
+                "state_dir": str(state_dir),
+                "socket_path": str(state_dir / "missing.sock"),
+            }
+            agent_a = FakePluginContext({**shared_config, "agent_id": "Agent A"})
+            agent_b = FakePluginContext({**shared_config, "agent_id": "Agent B"})
+            plugin.register(agent_a)
+            plugin.register(agent_b)
+
+            agent_a.hooks["pre_tool_call"](
+                session_id="shared-session",
+                platform="desktop",
+                tool_name="clarify",
+            )
+            agent_b.hooks["on_session_activate"](
+                session_id="shared-session",
+                running=True,
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            activation = events[-1]
+            self.assertEqual(activation["hook_event_name"], "SessionActivate")
+            self.assertEqual(activation["sidepulse_mode"], "working")
+            self.assertEqual(activation["surface"], "unknown")
+            self.assertNotEqual(activation["agent_id"], events[-2]["agent_id"])
+
+    def test_running_activation_does_not_reuse_wait_state_from_other_session(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_tool_call"](
+                session_id="session-a",
+                platform="desktop",
+                tool_name="clarify",
+            )
+            ctx.hooks["on_session_activate"](
+                session_id="session-b",
+                platform="desktop",
+                running=True,
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual(events[-1]["sidepulse_mode"], "working")
 
     def test_approval_surface_does_not_replace_desktop_session_surface(self) -> None:
         plugin = load_plugin_module()

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import io
+import json
+import socket
+import sys
+import tempfile
+import threading
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "integrations" / "hermes"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location(
+        "hermes_sidepulse_under_test",
+        PLUGIN_ROOT / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_ROOT)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load Hermes SidePulse plugin")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakePluginContext:
+    profile_name = "default"
+
+    def __init__(self, config=None) -> None:
+        self.config = config or {}
+        self.hooks = {}
+        self.cli_commands = {}
+
+    def get_config(self, key, default=None):
+        return self.config.get(key, default)
+
+    def register_hook(self, name, callback) -> None:
+        self.hooks[name] = callback
+
+    def register_cli_command(self, *, name, help, setup_fn, handler_fn) -> None:
+        self.cli_commands[name] = {
+            "help": help,
+            "setup_fn": setup_fn,
+            "handler_fn": handler_fn,
+        }
+
+
+class HermesBridgeTests(unittest.TestCase):
+    def test_pre_llm_event_exposes_only_status_metadata(self) -> None:
+        bridge = importlib.import_module("bridge")
+
+        settings = bridge.PluginSettings(agent_id="EDI")
+        event = bridge.translate_hook(
+            "pre_llm_call",
+            {
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "platform": "desktop",
+                "user_message": "private user prompt",
+                "conversation_history": [
+                    {"role": "user", "content": "private history"}
+                ],
+            },
+            settings,
+            now="2026-08-14T14:00:00Z",
+        )
+
+        self.assertEqual(
+            event,
+            {
+                "logged_at": "2026-08-14T14:00:00Z",
+                "hook_event_name": "UserPromptSubmit",
+                "integration": "hermes-plugin",
+                "agent_id": "EDI:84097828fc31",
+                "agent_origin": "Hermes Desktop",
+                "agent_origin_kind": "hermes_desktop",
+                "sidepulse_mode": "working",
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "surface": "desktop",
+            },
+        )
+        serialized = json.dumps(event)
+        self.assertNotIn("private user prompt", serialized)
+        self.assertNotIn("private history", serialized)
+
+    def test_session_key_is_never_persisted_as_session_id(self) -> None:
+        bridge = importlib.import_module("bridge")
+        event = bridge.translate_hook(
+            "pre_approval_request",
+            {
+                "session_key": "telegram:private-chat-12345",
+                "surface": "gateway",
+            },
+            bridge.PluginSettings(agent_id="EDI"),
+            now="2026-08-14T14:00:00Z",
+        )
+
+        self.assertIsNotNone(event)
+        self.assertNotIn("session_id", event)
+        self.assertNotIn("private-chat-12345", json.dumps(event))
+
+    def test_structured_tool_fallback_cannot_leak_arguments(self) -> None:
+        bridge = importlib.import_module("bridge")
+        marker = "PRIVATE_TOOL_ARGUMENT"
+        event = bridge.translate_hook(
+            "pre_tool_call",
+            {
+                "tool": {
+                    "name": "terminal",
+                    "args": {"command": f"printf {marker}"},
+                },
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "platform": "desktop",
+            },
+            bridge.PluginSettings(agent_id="EDI"),
+            now="2026-08-14T12:00:00+00:00",
+        )
+        serialized = json.dumps(event)
+        self.assertNotIn(marker, serialized)
+        self.assertNotIn("tool_name", event)
+
+    def test_lifecycle_hooks_map_to_expected_sidepulse_states(self) -> None:
+        bridge = importlib.import_module("bridge")
+        settings = bridge.PluginSettings(agent_id="EDI")
+        cases = [
+            ("on_session_start", {}, "SessionStart", "idle_ready"),
+            ("pre_tool_call", {"tool_name": "terminal"}, "PreToolUse", "tool_running"),
+            (
+                "pre_tool_call",
+                {"tool_name": "clarify"},
+                "PermissionRequest",
+                "waiting_for_input",
+            ),
+            (
+                "post_tool_call",
+                {"tool_name": "terminal", "status": "ok"},
+                "PostToolUse",
+                "working",
+            ),
+            (
+                "post_tool_call",
+                {"tool_name": "terminal", "status": "error"},
+                "PostToolUseFailure",
+                "blocked_error",
+            ),
+            ("pre_approval_request", {}, "PermissionRequest", "waiting_for_input"),
+            (
+                "post_approval_response",
+                {"choice": "deny"},
+                "PermissionDenied",
+                "blocked_error",
+            ),
+            (
+                "post_approval_response",
+                {"choice": "once"},
+                "UserPromptSubmit",
+                "working",
+            ),
+            ("api_request_error", {}, "StopFailure", "blocked_error"),
+            ("on_session_reset", {}, "SessionStart", "idle_ready"),
+        ]
+
+        for hook_name, extra, expected_event, expected_mode in cases:
+            with self.subTest(hook_name=hook_name, extra=extra):
+                payload = {
+                    "session_id": "session-1",
+                    "turn_id": "turn-1",
+                    "platform": "desktop",
+                    **extra,
+                }
+                event = bridge.translate_hook(
+                    hook_name,
+                    payload,
+                    settings,
+                    now="2026-08-14T14:00:00Z",
+                )
+                self.assertIsNotNone(event)
+                self.assertEqual(event["hook_event_name"], expected_event)
+                self.assertEqual(event["sidepulse_mode"], expected_mode)
+                if "tool_name" in extra:
+                    self.assertEqual(event["tool_name"], extra["tool_name"])
+
+    def test_approval_delivery_failures_map_to_blocked_error(self) -> None:
+        bridge = importlib.import_module("bridge")
+        settings = bridge.PluginSettings(agent_id="EDI")
+        failure_choices = (
+            "notify_failed",
+            "transport_busy",
+            "transport_error",
+            "transport_interrupted",
+            "transport_timeout",
+            "transport_invalid",
+            "transport_stale",
+        )
+
+        for choice in failure_choices:
+            with self.subTest(choice=choice):
+                event = bridge.translate_hook(
+                    "post_approval_response",
+                    {
+                        "session_id": "session-1",
+                        "platform": "desktop",
+                        "choice": choice,
+                    },
+                    settings,
+                    now="2026-08-14T14:00:00Z",
+                )
+                self.assertEqual(event["hook_event_name"], "PermissionDenied")
+                self.assertEqual(event["sidepulse_mode"], "blocked_error")
+
+    def test_same_profile_sessions_emit_distinct_status_identities(self) -> None:
+        bridge = importlib.import_module("bridge")
+        settings = bridge.PluginSettings(agent_id="EDI")
+        first = bridge.translate_hook(
+            "pre_llm_call",
+            {"session_id": "session-a", "platform": "desktop"},
+            settings,
+            now="2026-08-14T14:00:00Z",
+        )
+        second = bridge.translate_hook(
+            "pre_llm_call",
+            {"session_id": "session-b", "platform": "desktop"},
+            settings,
+            now="2026-08-14T14:00:01Z",
+        )
+
+        self.assertNotEqual(first["agent_id"], second["agent_id"])
+        self.assertRegex(first["agent_id"], r"^EDI:[0-9a-f]{12}$")
+        self.assertRegex(second["agent_id"], r"^EDI:[0-9a-f]{12}$")
+        self.assertNotIn("session-a", first["agent_id"])
+        self.assertNotIn("session-b", second["agent_id"])
+
+    def test_final_response_uses_explicit_marker_without_persisting_response(
+        self,
+    ) -> None:
+        bridge = importlib.import_module("bridge")
+        event = bridge.translate_hook(
+            "post_llm_call",
+            {
+                "session_id": "session-1",
+                "platform": "desktop",
+                "assistant_response": "Sensitive response text.\n<!-- sidepulse:ask -->",
+            },
+            bridge.PluginSettings(agent_id="EDI"),
+            now="2026-08-14T14:00:00Z",
+        )
+
+        self.assertEqual(event["hook_event_name"], "Stop")
+        self.assertEqual(event["sidepulse_mode"], "waiting_for_input")
+        self.assertNotIn("Sensitive response text", json.dumps(event))
+
+    def test_emit_hook_logs_metadata_and_sends_sidepulse_socket_event(self) -> None:
+        bridge = importlib.import_module("bridge")
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            socket_path = state_dir / "events.sock"
+            received = []
+            ready = threading.Event()
+
+            def receive_one() -> None:
+                server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    server.bind(str(socket_path))
+                    server.listen(1)
+                    ready.set()
+                    connection, _ = server.accept()
+                    with connection:
+                        chunks = []
+                        while True:
+                            chunk = connection.recv(65536)
+                            if not chunk:
+                                break
+                            chunks.append(chunk)
+                    received.append(json.loads(b"".join(chunks).decode("utf-8")))
+                finally:
+                    server.close()
+
+            receiver = threading.Thread(target=receive_one, daemon=True)
+            receiver.start()
+            self.assertTrue(ready.wait(timeout=2))
+
+            result = bridge.emit_hook(
+                "pre_tool_call",
+                {
+                    "session_id": "session-1",
+                    "turn_id": "turn-1",
+                    "platform": "desktop",
+                    "tool_name": "terminal",
+                    "args": {"command": "private command"},
+                },
+                bridge.PluginSettings(
+                    agent_id="EDI",
+                    state_dir=state_dir,
+                    socket_path=socket_path,
+                ),
+                now="2026-08-14T14:00:00Z",
+            )
+            receiver.join(timeout=2)
+
+            self.assertTrue(result.logged)
+            self.assertTrue(result.delivered)
+            self.assertEqual(received[0]["provider"], "hermes")
+            self.assertEqual(received[0]["line"]["integration"], "hermes-plugin")
+            self.assertEqual(received[0]["line"]["hook_event_name"], "PreToolUse")
+            self.assertNotIn("private command", json.dumps(received[0]))
+            log_lines = (state_dir / "hermes.jsonl").read_text().splitlines()
+            self.assertEqual(len(log_lines), 1)
+            self.assertEqual(json.loads(log_lines[0]), received[0]["line"])
+
+    def test_event_log_is_created_owner_read_write_only(self) -> None:
+        bridge = importlib.import_module("bridge")
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            previous_umask = __import__("os").umask(0o022)
+            try:
+                result = bridge.emit_hook(
+                    "pre_llm_call",
+                    {"session_id": "session-1", "platform": "desktop"},
+                    bridge.PluginSettings(
+                        state_dir=state_dir,
+                        socket_path=state_dir / "missing.sock",
+                    ),
+                    now="2026-08-14T14:00:00Z",
+                )
+            finally:
+                __import__("os").umask(previous_umask)
+
+            self.assertTrue(result.logged)
+            mode = (state_dir / "hermes.jsonl").stat().st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+
+    def test_surface_recovery_skips_deeply_nested_corrupt_line(self) -> None:
+        bridge = importlib.import_module("bridge")
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            event_log = state_dir / "hermes.jsonl"
+            event_log.write_text(
+                json.dumps(
+                    {
+                        "hook_event_name": "SessionStart",
+                        "session_id": "session-a",
+                        "surface": "desktop",
+                    }
+                )
+                + "\n"
+                + "[" * 2_000
+                + "0"
+                + "]" * 2_000
+                + "\n",
+                encoding="utf-8",
+            )
+
+            recovered = bridge.recover_session_surface(
+                bridge.PluginSettings(state_dir=state_dir, log_events=True),
+                "session-a",
+            )
+
+            self.assertEqual(recovered, "desktop")
+
+    def test_surface_recovery_caps_read_when_log_grows_concurrently(self) -> None:
+        bridge = importlib.import_module("bridge")
+        initial = (
+            json.dumps(
+                {
+                    "hook_event_name": "SessionStart",
+                    "session_id": "session-a",
+                    "surface": "desktop",
+                }
+            ).encode("utf-8")
+            + b"\n"
+        )
+
+        class GrowingLog(io.BytesIO):
+            def __init__(self) -> None:
+                super().__init__(initial)
+                self.grow_on_next_seek = False
+                self.read_sizes = []
+
+            def seek(self, offset, whence=0):
+                position = super().seek(offset, whence)
+                if whence == 2:
+                    self.grow_on_next_seek = True
+                elif self.grow_on_next_seek:
+                    self.grow_on_next_seek = False
+                    original_position = position
+                    super().seek(0, 2)
+                    super().write(b"{}\n" * (1024 * 1024))
+                    super().seek(original_position)
+                return position
+
+            def read(self, size: int | None = -1):
+                self.read_sizes.append(size)
+                return super().read(size)
+
+        growing_log = GrowingLog()
+        with patch("builtins.open", return_value=growing_log):
+            recovered = bridge.recover_session_surface(
+                bridge.PluginSettings(log_events=True),
+                "session-a",
+            )
+
+        self.assertEqual(recovered, "desktop")
+        self.assertEqual(growing_log.read_sizes, [len(initial)])
+        self.assertLessEqual(growing_log.read_sizes[0], 1024 * 1024)
+
+    def test_surface_recovery_ignores_stale_cli_approval_record(self) -> None:
+        bridge = importlib.import_module("bridge")
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            event_log = state_dir / "hermes.jsonl"
+            records = (
+                {
+                    "hook_event_name": "SessionStart",
+                    "session_id": "session-a",
+                    "surface": "desktop",
+                },
+                {
+                    "hook_event_name": "PermissionRequest",
+                    "session_id": "session-a",
+                    "surface": "cli",
+                },
+                {
+                    "hook_event_name": "PermissionDenied",
+                    "session_id": "session-a",
+                    "surface": "cli",
+                },
+            )
+            event_log.write_text(
+                "".join(json.dumps(record) + "\n" for record in records),
+                encoding="utf-8",
+            )
+
+            recovered = bridge.recover_session_surface(
+                bridge.PluginSettings(state_dir=state_dir, log_events=True),
+                "session-a",
+            )
+
+            self.assertEqual(recovered, "desktop")
+
+    def test_emit_hook_degrades_to_log_when_status_bar_socket_is_absent(self) -> None:
+        bridge = importlib.import_module("bridge")
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            result = bridge.emit_hook(
+                "pre_llm_call",
+                {"session_id": "session-1", "platform": "desktop"},
+                bridge.PluginSettings(
+                    state_dir=state_dir,
+                    socket_path=state_dir / "missing.sock",
+                ),
+                now="2026-08-14T14:00:00Z",
+            )
+
+            self.assertTrue(result.logged)
+            self.assertFalse(result.delivered)
+            self.assertTrue((state_dir / "hermes.jsonl").is_file())
+
+    def test_successful_session_end_does_not_overwrite_final_response_state(
+        self,
+    ) -> None:
+        bridge = importlib.import_module("bridge")
+        event = bridge.translate_hook(
+            "on_session_end",
+            {"completed": True, "interrupted": False},
+            bridge.PluginSettings(),
+            now="2026-08-14T14:00:00Z",
+        )
+        self.assertIsNone(event)
+
+
+class HermesPluginRegistrationTests(unittest.TestCase):
+    def test_register_wires_observer_hooks_without_model_facing_tools(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+
+            plugin.register(ctx)
+
+            self.assertEqual(
+                set(ctx.hooks),
+                {
+                    "on_session_start",
+                    "on_session_reset",
+                    "pre_llm_call",
+                    "pre_tool_call",
+                    "post_tool_call",
+                    "pre_approval_request",
+                    "post_approval_response",
+                    "api_request_error",
+                    "post_llm_call",
+                    "on_session_end",
+                },
+            )
+            self.assertEqual(set(ctx.cli_commands), {"sidepulse"})
+            result = ctx.hooks["pre_llm_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                platform="desktop",
+                user_message="private prompt",
+            )
+            self.assertIsNone(result)
+            event = json.loads((state_dir / "hermes.jsonl").read_text().strip())
+            self.assertRegex(event["agent_id"], r"^EDI:[0-9a-f]{12}$")
+            self.assertEqual(event["surface"], "desktop")
+            self.assertNotIn("private prompt", json.dumps(event))
+
+    def test_approval_surface_does_not_replace_desktop_session_surface(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_llm_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                platform="desktop",
+            )
+            ctx.hooks["pre_approval_request"](
+                session_key="telegram:private-chat-12345",
+                turn_id="turn-1",
+                surface="gateway",
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            approval = events[-1]
+            self.assertEqual(approval["session_id"], "session-1")
+            self.assertEqual(approval["surface"], "desktop")
+            self.assertEqual(approval["agent_origin"], "Hermes Desktop")
+            self.assertNotIn("private-chat-12345", json.dumps(approval))
+
+    def test_session_end_clears_turn_surface_correlation(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_llm_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                platform="desktop",
+            )
+            ctx.hooks["on_session_end"](
+                session_id="session-1",
+                turn_id="turn-1",
+                completed=True,
+                interrupted=False,
+            )
+            ctx.hooks["pre_approval_request"](
+                session_key="telegram:private-chat-12345",
+                turn_id="turn-1",
+                surface="gateway",
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            approval = events[-1]
+            self.assertNotIn("session_id", approval)
+            self.assertEqual(approval["surface"], "unknown")
+            self.assertEqual(approval["agent_origin"], "Hermes")
+            self.assertNotIn("private-chat-12345", json.dumps(approval))
+
+    def test_tool_hook_reuses_desktop_surface_from_same_session(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_llm_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                platform="desktop",
+            )
+            ctx.hooks["pre_tool_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                tool_name="terminal",
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual(events[-1]["surface"], "desktop")
+            self.assertEqual(events[-1]["agent_origin"], "Hermes Desktop")
+
+    def test_surface_cache_survives_plugin_reregistration(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            config = {
+                "agent_id": "EDI",
+                "state_dir": str(state_dir),
+                "socket_path": str(state_dir / "missing.sock"),
+            }
+            first_context = FakePluginContext(config)
+            plugin.register(first_context)
+            first_context.hooks["pre_llm_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                platform="desktop",
+            )
+
+            second_context = FakePluginContext(config)
+            reloaded_plugin = load_plugin_module()
+            reloaded_plugin.register(second_context)
+            second_context.hooks["pre_tool_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                tool_name="terminal",
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual(events[-1]["surface"], "desktop")
+            self.assertEqual(events[-1]["agent_origin"], "Hermes Desktop")
+
+    def test_string_false_disables_event_logging(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                    "log_events": "false",
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_llm_call"](
+                session_id="session-1",
+                turn_id="turn-1",
+                platform="desktop",
+            )
+
+            self.assertFalse((state_dir / "hermes.jsonl").exists())
+
+    def test_doctor_command_reports_transport_paths_as_json(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            event_log = state_dir / "hermes.jsonl"
+            event_log.write_text('{"hook_event_name":"SessionStart"}\n')
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+            command = ctx.cli_commands["sidepulse"]
+            parser = argparse.ArgumentParser()
+            command["setup_fn"](parser)
+            args = parser.parse_args(["doctor", "--json"])
+
+            output = io.StringIO()
+            with redirect_stdout(output):
+                command["handler_fn"](args)
+            report = json.loads(output.getvalue())
+
+            self.assertEqual(report["agent_id"], "EDI")
+            self.assertEqual(report["provider"], "hermes")
+            self.assertEqual(report["state_dir"], str(state_dir))
+            self.assertTrue(report["event_log_exists"])
+            self.assertFalse(report["socket_exists"])
+            self.assertEqual(report["socket_path"], str(state_dir / "missing.sock"))
+
+    def test_cli_test_command_emits_requested_status(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+            command = ctx.cli_commands["sidepulse"]
+            parser = argparse.ArgumentParser()
+            command["setup_fn"](parser)
+            args = parser.parse_args(["test", "--mode", "done", "--json"])
+
+            output = io.StringIO()
+            with redirect_stdout(output):
+                command["handler_fn"](args)
+            report = json.loads(output.getvalue())
+
+            self.assertEqual(report["mode"], "completed")
+            self.assertTrue(report["logged"])
+            self.assertFalse(report["delivered"])
+            event = json.loads((state_dir / "hermes.jsonl").read_text().strip())
+            self.assertEqual(event["hook_event_name"], "Stop")
+            self.assertEqual(event["sidepulse_mode"], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -291,6 +291,22 @@ class HermesBridgeTests(unittest.TestCase):
         self.assertEqual(event["sidepulse_mode"], "waiting_for_input")
         self.assertNotIn("Sensitive response text", json.dumps(event))
 
+    def test_casual_work_invitation_does_not_leave_agent_waiting(self) -> None:
+        bridge = importlib.import_module("bridge")
+        event = bridge.translate_hook(
+            "post_llm_call",
+            {
+                "session_id": "session-1",
+                "platform": "desktop",
+                "assistant_response": "Got it — I'm here. What do you want to work on?",
+            },
+            bridge.PluginSettings(agent_id="EDI", profile_name="developer"),
+            now="2026-08-16T00:49:43Z",
+        )
+
+        self.assertEqual(event["hook_event_name"], "Stop")
+        self.assertEqual(event["sidepulse_mode"], "completed")
+
     def test_emit_hook_logs_metadata_and_sends_sidepulse_socket_event(self) -> None:
         bridge = importlib.import_module("bridge")
         with tempfile.TemporaryDirectory(dir="/tmp") as tmp:

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -56,10 +56,39 @@ class FakePluginContext:
 
 
 class HermesBridgeTests(unittest.TestCase):
+    def test_event_carries_profile_selector_for_scoped_session_lookup(self) -> None:
+        bridge = importlib.import_module("bridge")
+        self.assertIn("profile_name", bridge.PluginSettings.__dataclass_fields__)
+        settings = bridge.PluginSettings(
+            agent_id="Homelab",
+            profile_name="homelab",
+        )
+
+        event = bridge.translate_hook(
+            "pre_llm_call",
+            {"session_id": "session-1", "platform": "desktop"},
+            settings,
+            now="2026-08-14T14:00:00Z",
+        )
+
+        self.assertEqual(event["hermes_profile"], "homelab")
+
+    def test_translate_hook_rejects_missing_profile_provenance(self) -> None:
+        bridge = importlib.import_module("bridge")
+
+        event = bridge.translate_hook(
+            "pre_llm_call",
+            {"session_id": "private-session", "platform": "desktop"},
+            bridge.PluginSettings(agent_id="EDI", profile_name=""),
+            now="2026-08-14T14:00:00Z",
+        )
+
+        self.assertIsNone(event)
+
     def test_pre_llm_event_exposes_only_status_metadata(self) -> None:
         bridge = importlib.import_module("bridge")
 
-        settings = bridge.PluginSettings(agent_id="EDI")
+        settings = bridge.PluginSettings(agent_id="EDI", profile_name="default")
         event = bridge.translate_hook(
             "pre_llm_call",
             {
@@ -81,11 +110,12 @@ class HermesBridgeTests(unittest.TestCase):
                 "logged_at": "2026-08-14T14:00:00Z",
                 "hook_event_name": "UserPromptSubmit",
                 "integration": "hermes-plugin",
-                "agent_id": "EDI:84097828fc31",
+                "agent_id": "EDI:4c60b8409c66",
                 "agent_origin": "Hermes Desktop",
                 "agent_origin_kind": "hermes_desktop",
                 "sidepulse_mode": "working",
                 "session_id": "session-1",
+                "hermes_profile": "default",
                 "turn_id": "turn-1",
                 "surface": "desktop",
             },
@@ -102,7 +132,7 @@ class HermesBridgeTests(unittest.TestCase):
                 "session_key": "telegram:private-chat-12345",
                 "surface": "gateway",
             },
-            bridge.PluginSettings(agent_id="EDI"),
+            bridge.PluginSettings(agent_id="EDI", profile_name="default"),
             now="2026-08-14T14:00:00Z",
         )
 
@@ -124,7 +154,7 @@ class HermesBridgeTests(unittest.TestCase):
                 "turn_id": "turn-1",
                 "platform": "desktop",
             },
-            bridge.PluginSettings(agent_id="EDI"),
+            bridge.PluginSettings(agent_id="EDI", profile_name="default"),
             now="2026-08-14T12:00:00+00:00",
         )
         serialized = json.dumps(event)
@@ -133,7 +163,7 @@ class HermesBridgeTests(unittest.TestCase):
 
     def test_lifecycle_hooks_map_to_expected_sidepulse_states(self) -> None:
         bridge = importlib.import_module("bridge")
-        settings = bridge.PluginSettings(agent_id="EDI")
+        settings = bridge.PluginSettings(agent_id="EDI", profile_name="default")
         cases = [
             ("on_session_start", {}, "SessionStart", "idle_ready"),
             ("pre_tool_call", {"tool_name": "terminal"}, "PreToolUse", "tool_running"),
@@ -194,7 +224,7 @@ class HermesBridgeTests(unittest.TestCase):
 
     def test_approval_delivery_failures_map_to_blocked_error(self) -> None:
         bridge = importlib.import_module("bridge")
-        settings = bridge.PluginSettings(agent_id="EDI")
+        settings = bridge.PluginSettings(agent_id="EDI", profile_name="default")
         failure_choices = (
             "notify_failed",
             "transport_busy",
@@ -222,7 +252,7 @@ class HermesBridgeTests(unittest.TestCase):
 
     def test_same_profile_sessions_emit_distinct_status_identities(self) -> None:
         bridge = importlib.import_module("bridge")
-        settings = bridge.PluginSettings(agent_id="EDI")
+        settings = bridge.PluginSettings(agent_id="EDI", profile_name="default")
         first = bridge.translate_hook(
             "pre_llm_call",
             {"session_id": "session-a", "platform": "desktop"},
@@ -253,7 +283,7 @@ class HermesBridgeTests(unittest.TestCase):
                 "platform": "desktop",
                 "assistant_response": "Sensitive response text.\n<!-- sidepulse:ask -->",
             },
-            bridge.PluginSettings(agent_id="EDI"),
+            bridge.PluginSettings(agent_id="EDI", profile_name="default"),
             now="2026-08-14T14:00:00Z",
         )
 
@@ -302,6 +332,7 @@ class HermesBridgeTests(unittest.TestCase):
                 },
                 bridge.PluginSettings(
                     agent_id="EDI",
+                    profile_name="default",
                     state_dir=state_dir,
                     socket_path=socket_path,
                 ),
@@ -329,6 +360,7 @@ class HermesBridgeTests(unittest.TestCase):
                     "pre_llm_call",
                     {"session_id": "session-1", "platform": "desktop"},
                     bridge.PluginSettings(
+                        profile_name="default",
                         state_dir=state_dir,
                         socket_path=state_dir / "missing.sock",
                     ),
@@ -341,6 +373,63 @@ class HermesBridgeTests(unittest.TestCase):
             mode = (state_dir / "hermes.jsonl").stat().st_mode & 0o777
             self.assertEqual(mode, 0o600)
 
+    def test_surface_recovery_requires_matching_profile_provenance(self) -> None:
+        bridge = importlib.import_module("bridge")
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            alpha = bridge.PluginSettings(
+                agent_id="EDI",
+                profile_name="alpha",
+                state_dir=state_dir,
+                log_events=True,
+            )
+            beta = bridge.PluginSettings(
+                agent_id="EDI",
+                profile_name="beta",
+                state_dir=state_dir,
+                log_events=True,
+            )
+            alpha_event = bridge.translate_hook(
+                "on_session_activate",
+                {
+                    "session_id": "imported-session",
+                    "platform": "desktop",
+                    "activation_mode": "working",
+                },
+                alpha,
+                now="2026-08-14T14:00:00Z",
+            )
+            missing_profile_event = {
+                **alpha_event,
+                "surface": "cli",
+                "sidepulse_mode": "blocked_error",
+            }
+            missing_profile_event.pop("hermes_profile")
+            (state_dir / "hermes.jsonl").write_text(
+                json.dumps(alpha_event)
+                + "\n"
+                + json.dumps(missing_profile_event)
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                bridge.recover_session_surface(alpha, "imported-session"),
+                "desktop",
+            )
+            self.assertEqual(
+                bridge.recover_session_mode(alpha, "imported-session"),
+                "working",
+            )
+            self.assertEqual(
+                bridge.recover_session_surface(beta, "imported-session"),
+                "",
+            )
+            self.assertEqual(
+                bridge.recover_session_mode(beta, "imported-session"),
+                "",
+            )
+
     def test_surface_recovery_skips_deeply_nested_corrupt_line(self) -> None:
         bridge = importlib.import_module("bridge")
         with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
@@ -349,9 +438,12 @@ class HermesBridgeTests(unittest.TestCase):
             event_log.write_text(
                 json.dumps(
                     {
-                        "agent_id": bridge._status_agent_id("Hermes", "session-a"),
+                        "agent_id": bridge._status_agent_id(
+                            "Hermes", "session-a", "default"
+                        ),
                         "hook_event_name": "SessionStart",
                         "integration": "hermes-plugin",
+                        "hermes_profile": "default",
                         "session_id": "session-a",
                         "surface": "desktop",
                     }
@@ -365,7 +457,11 @@ class HermesBridgeTests(unittest.TestCase):
             )
 
             recovered = bridge.recover_session_surface(
-                bridge.PluginSettings(state_dir=state_dir, log_events=True),
+                bridge.PluginSettings(
+                    profile_name="default",
+                    state_dir=state_dir,
+                    log_events=True,
+                ),
                 "session-a",
             )
 
@@ -376,9 +472,10 @@ class HermesBridgeTests(unittest.TestCase):
         initial = (
             json.dumps(
                 {
-                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a", "default"),
                     "hook_event_name": "SessionStart",
                     "integration": "hermes-plugin",
+                    "hermes_profile": "default",
                     "session_id": "session-a",
                     "surface": "desktop",
                 }
@@ -411,7 +508,7 @@ class HermesBridgeTests(unittest.TestCase):
         growing_log = GrowingLog()
         with patch("builtins.open", return_value=growing_log):
             recovered = bridge.recover_session_surface(
-                bridge.PluginSettings(log_events=True),
+                bridge.PluginSettings(profile_name="default", log_events=True),
                 "session-a",
             )
 
@@ -426,23 +523,26 @@ class HermesBridgeTests(unittest.TestCase):
             event_log = state_dir / "hermes.jsonl"
             records = (
                 {
-                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a", "default"),
                     "hook_event_name": "SessionStart",
                     "integration": "hermes-plugin",
+                    "hermes_profile": "default",
                     "session_id": "session-a",
                     "surface": "desktop",
                 },
                 {
-                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a", "default"),
                     "hook_event_name": "PermissionRequest",
                     "integration": "hermes-plugin",
+                    "hermes_profile": "default",
                     "session_id": "session-a",
                     "surface": "cli",
                 },
                 {
-                    "agent_id": bridge._status_agent_id("Hermes", "session-a"),
+                    "agent_id": bridge._status_agent_id("Hermes", "session-a", "default"),
                     "hook_event_name": "PermissionDenied",
                     "integration": "hermes-plugin",
+                    "hermes_profile": "default",
                     "session_id": "session-a",
                     "surface": "cli",
                 },
@@ -453,7 +553,11 @@ class HermesBridgeTests(unittest.TestCase):
             )
 
             recovered = bridge.recover_session_surface(
-                bridge.PluginSettings(state_dir=state_dir, log_events=True),
+                bridge.PluginSettings(
+                    profile_name="default",
+                    state_dir=state_dir,
+                    log_events=True,
+                ),
                 "session-a",
             )
 
@@ -467,6 +571,7 @@ class HermesBridgeTests(unittest.TestCase):
                 "pre_llm_call",
                 {"session_id": "session-1", "platform": "desktop"},
                 bridge.PluginSettings(
+                    profile_name="default",
                     state_dir=state_dir,
                     socket_path=state_dir / "missing.sock",
                 ),
@@ -593,6 +698,52 @@ class HermesPluginRegistrationTests(unittest.TestCase):
 
             event = json.loads((state_dir / "hermes.jsonl").read_text().strip())
             self.assertEqual(event["sidepulse_mode"], "working")
+
+    def test_sessionless_tool_hook_is_not_emitted(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["pre_tool_call"](tool_name="terminal")
+
+            self.assertFalse((state_dir / "hermes.jsonl").exists())
+
+    def test_profileless_context_does_not_emit_observer_status(self) -> None:
+        plugin = load_plugin_module()
+
+        class ProfilelessContext(FakePluginContext):
+            profile_name = None
+
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = ProfilelessContext(
+                {
+                    "agent_id": "EDI",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+
+            settings = plugin._settings_from_context(ctx)
+            self.assertEqual(settings.profile_name, "")
+            plugin.register(ctx)
+            with patch.object(plugin, "emit_hook") as emit:
+                ctx.hooks["pre_llm_call"](
+                    session_id="private-session",
+                    turn_id="private-turn",
+                    platform="desktop",
+                )
+
+            emit.assert_not_called()
+            self.assertFalse((state_dir / "hermes.jsonl").exists())
 
     def test_session_activation_recovery_is_scoped_to_agent_provenance(self) -> None:
         plugin = load_plugin_module()
@@ -725,11 +876,10 @@ class HermesPluginRegistrationTests(unittest.TestCase):
                 json.loads(line)
                 for line in (state_dir / "hermes.jsonl").read_text().splitlines()
             ]
-            approval = events[-1]
-            self.assertNotIn("session_id", approval)
-            self.assertEqual(approval["surface"], "unknown")
-            self.assertEqual(approval["agent_origin"], "Hermes")
-            self.assertNotIn("private-chat-12345", json.dumps(approval))
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["hook_event_name"], "UserPromptSubmit")
+            self.assertEqual(events[0]["session_id"], "session-1")
+            self.assertNotIn("private-chat-12345", json.dumps(events))
 
     def test_tool_hook_reuses_desktop_surface_from_same_session(self) -> None:
         plugin = load_plugin_module()
@@ -816,6 +966,10 @@ class HermesPluginRegistrationTests(unittest.TestCase):
             )
 
             self.assertFalse((state_dir / "hermes.jsonl").exists())
+
+    def test_manifest_declares_cross_profile_shared_scope(self) -> None:
+        manifest = (PLUGIN_ROOT / "plugin.yaml").read_text(encoding="utf-8")
+        self.assertRegex(manifest, r"(?m)^profile_scope:\s*shared\s*$")
 
     def test_doctor_command_reports_transport_paths_as_json(self) -> None:
         plugin = load_plugin_module()

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -166,6 +166,7 @@ class HermesBridgeTests(unittest.TestCase):
         settings = bridge.PluginSettings(agent_id="EDI", profile_name="default")
         cases = [
             ("on_session_start", {}, "SessionStart", "idle_ready"),
+            ("on_session_finalize", {"reason": "shutdown"}, "SessionFinalize", "completed"),
             ("pre_tool_call", {"tool_name": "terminal"}, "PreToolUse", "tool_running"),
             (
                 "pre_tool_call",
@@ -640,6 +641,7 @@ class HermesPluginRegistrationTests(unittest.TestCase):
                     "api_request_error",
                     "post_llm_call",
                     "on_session_end",
+                    "on_session_finalize",
                 },
             )
             self.assertEqual(set(ctx.cli_commands), {"sidepulse"})
@@ -654,6 +656,35 @@ class HermesPluginRegistrationTests(unittest.TestCase):
             self.assertRegex(event["agent_id"], r"^EDI:[0-9a-f]{12}$")
             self.assertEqual(event["surface"], "desktop")
             self.assertNotIn("private prompt", json.dumps(event))
+
+    def test_session_finalize_emits_completed_event(self) -> None:
+        plugin = load_plugin_module()
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            state_dir = Path(tmp)
+            ctx = FakePluginContext(
+                {
+                    "agent_id": "EDI",
+                    "profile_name": "default",
+                    "state_dir": str(state_dir),
+                    "socket_path": str(state_dir / "missing.sock"),
+                }
+            )
+            plugin.register(ctx)
+
+            ctx.hooks["on_session_finalize"](
+                session_id="session-finalize",
+                platform="desktop",
+                reason="shutdown",
+            )
+
+            events = [
+                json.loads(line)
+                for line in (state_dir / "hermes.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["hook_event_name"], "SessionFinalize")
+            self.assertEqual(events[0]["sidepulse_mode"], "completed")
+            self.assertEqual(events[0]["surface"], "desktop")
 
     def test_session_activation_reasserts_running_wait_state_or_idle(self) -> None:
         plugin = load_plugin_module()

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -251,6 +251,29 @@ class AgentMonitorTests(unittest.TestCase):
                 is not None
             )
 
+    def test_hermes_session_activate_is_parsed_with_explicit_status(self) -> None:
+        record = parse_log_line(
+            "hermes",
+            json.dumps(
+                {
+                    "hook_event_name": "SessionActivate",
+                    "session_id": "durable-session",
+                    "integration": "hermes-plugin",
+                    "agent_id": "hermes:durable-session",
+                    "sidepulse_status": "working",
+                    "logged_at": "2026-08-14T12:00:00Z",
+                }
+            ),
+        )
+
+        self.assertIsNotNone(record)
+        assert record is not None
+        status = collector_module.status_from_event(record)
+        self.assertIsNotNone(status)
+        assert status is not None
+        self.assertEqual(status.mode, AgentMode.WORKING)
+        self.assertEqual(status.event_name, "SessionActivate")
+
     def test_hook_payload_stamps_origin_from_vscode_environment(self) -> None:
         with patch.dict(os.environ, {"TERM_PROGRAM": "vscode"}, clear=True):
             line = format_hook_payload(

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -318,6 +318,51 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertEqual(status.mode, AgentMode.COMPLETED)
         self.assertEqual(status.event_name, "SessionFinalize")
 
+    def test_hermes_completion_clears_prior_agent_identity_in_same_session(self) -> None:
+        def hermes_event(event_name: str, agent_id: str, logged_at: str):
+            return parse_log_line(
+                "hermes",
+                json.dumps(
+                    {
+                        "hook_event_name": event_name,
+                        "session_id": "same-session",
+                        "hermes_profile": "default",
+                        "integration": "hermes-plugin",
+                        "agent_id": agent_id,
+                        "sidepulse_mode": "working" if event_name == "UserPromptSubmit" else "completed",
+                        "logged_at": logged_at,
+                    }
+                ),
+            )
+
+        monitor = LiveAgentMonitor(
+            sources=(),
+            stale_after_seconds=999999999,
+            completed_visible_seconds=999999999,
+        )
+        active = hermes_event(
+            "UserPromptSubmit",
+            "EDI:old-agent",
+            "2026-08-16T12:00:00Z",
+        )
+        completed = hermes_event(
+            "Stop",
+            "EDI:new-agent",
+            "2026-08-16T12:00:01Z",
+        )
+
+        self.assertIsNotNone(active)
+        self.assertIsNotNone(completed)
+        assert active is not None
+        assert completed is not None
+        monitor.ingest_record(active)
+        monitor.ingest_record(completed)
+
+        snapshot = monitor.snapshot()
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
+        self.assertEqual(len(snapshot.statuses), 1)
+        self.assertEqual(snapshot.statuses[0].event_name, "Stop")
+
     def test_sessionless_hermes_tool_event_does_not_create_active_status(self) -> None:
         record = parse_log_line(
             "hermes",

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 import os
 import plistlib
+import sqlite3
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -29,6 +32,7 @@ from sidepulse.battery import (
     BatterySnapshot,
     parse_ioreg_battery_plist,
     program_for_battery,
+    should_arm_battery_power_preview,
 )
 from sidepulse import collector as collector_module
 from sidepulse import cli as cli_module
@@ -66,6 +70,7 @@ from sidepulse.led_status import (
     display_state_for_mode,
     led_count_for_target,
     program_for_display_state,
+    resolve_led_display_kind,
     write_mode_to_leds,
 )
 from sidepulse.lid_sleep import (
@@ -87,6 +92,8 @@ from sidepulse.providers import (
     detect_grok_config,
     default_log_path,
     default_state_dir,
+    hermes_session_metadata_from_db,
+    hermes_state_db_paths,
     parse_log_line,
 )
 from sidepulse.sd_eject_guard_launch import (
@@ -122,6 +129,8 @@ from sidepulse.settings import (
     HISTORY_TIMEFRAME_48H_SECONDS,
     LID_ANIMATION_CLOSED,
     LID_ANIMATION_OPEN,
+    LED_DISPLAY_AGENT,
+    LED_DISPLAY_BATTERY,
     LED_DISPLAY_CUSTOM,
     SLEEP_PREVENTION_AGENTS,
     SLEEP_PREVENTION_ALWAYS,
@@ -168,6 +177,16 @@ class FakeProcess:
 
     def kill(self) -> None:
         self.killed = True
+
+
+@contextmanager
+def sqlite_connection(path: Path):
+    connection = sqlite3.connect(path)
+    try:
+        yield connection
+        connection.commit()
+    finally:
+        connection.close()
 
 
 class AgentMonitorTests(unittest.TestCase):
@@ -258,6 +277,7 @@ class AgentMonitorTests(unittest.TestCase):
                 {
                     "hook_event_name": "SessionActivate",
                     "session_id": "durable-session",
+                    "hermes_profile": "default",
                     "integration": "hermes-plugin",
                     "agent_id": "hermes:durable-session",
                     "sidepulse_status": "working",
@@ -273,6 +293,550 @@ class AgentMonitorTests(unittest.TestCase):
         assert status is not None
         self.assertEqual(status.mode, AgentMode.WORKING)
         self.assertEqual(status.event_name, "SessionActivate")
+
+    def test_sessionless_hermes_tool_event_does_not_create_active_status(self) -> None:
+        record = parse_log_line(
+            "hermes",
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "integration": "hermes-plugin",
+                    "agent_id": "EDI",
+                    "hermes_profile": "default",
+                    "sidepulse_mode": "tool_running",
+                    "tool_name": "terminal",
+                    "logged_at": "2026-08-15T14:32:10Z",
+                }
+            ),
+        )
+
+        self.assertIsNotNone(record)
+        assert record is not None
+        self.assertIsNone(collector_module.status_from_event(record))
+
+    def test_hermes_compression_lineage_coalesces_and_uses_chat_title(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_db = Path(tmp) / "state.db"
+            with sqlite_connection(state_db) as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        id TEXT PRIMARY KEY,
+                        parent_session_id TEXT,
+                        title TEXT,
+                        started_at TEXT,
+                        end_reason TEXT,
+                        source TEXT,
+                        model_config TEXT
+                    )
+                    """
+                )
+                connection.executemany(
+                    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        (
+                            "root-session",
+                            None,
+                            None,
+                            "2026-08-14T12:00:00Z",
+                            "compression",
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "compressed-session",
+                            "root-session",
+                            "Verify SidePulse after Hermes updates",
+                            "2026-08-14T12:05:00Z",
+                            None,
+                            "desktop",
+                            None,
+                        ),
+                    ),
+                )
+
+            def hermes_event(session_id: str, agent_id: str):
+                return parse_log_line(
+                    "hermes",
+                    json.dumps(
+                        {
+                            "hook_event_name": "SessionActivate",
+                            "session_id": session_id,
+                            "integration": "hermes-plugin",
+                            "agent_id": agent_id,
+                            "sidepulse_status": "working",
+                            "logged_at": "2026-08-14T12:06:00Z",
+                        }
+                    ),
+                )
+
+            with patch.dict(
+                os.environ,
+                {"SIDEPULSE_HERMES_STATE_DB": str(state_db)},
+                clear=False,
+            ):
+                root_record = hermes_event("root-session", "EDI:root-fragment")
+                child_record = hermes_event("compressed-session", "EDI:child-fragment")
+
+            self.assertIsNotNone(root_record)
+            self.assertIsNotNone(child_record)
+            assert root_record is not None
+            assert child_record is not None
+            self.assertEqual(root_record.agent_id, child_record.agent_id)
+
+            child_status = collector_module.status_from_event(child_record)
+            self.assertIsNotNone(child_status)
+            assert child_status is not None
+            self.assertIn(
+                "Verify SidePulse after Hermes updates",
+                child_status.display_name,
+            )
+
+    def test_hermes_compression_walk_avoids_stale_sibling_continuation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_db = Path(tmp) / "state.db"
+            with sqlite_connection(state_db) as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        id TEXT PRIMARY KEY,
+                        parent_session_id TEXT,
+                        title TEXT,
+                        started_at TEXT,
+                        end_reason TEXT,
+                        source TEXT,
+                        model_config TEXT
+                    )
+                    """
+                )
+                connection.executemany(
+                    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        (
+                            "root-session",
+                            None,
+                            "Original title",
+                            "2026-08-14T12:00:00Z",
+                            "compression",
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "stale-sibling",
+                            "root-session",
+                            "Stale sibling title",
+                            "2026-08-14T12:01:00Z",
+                            None,
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "live-continuation",
+                            "root-session",
+                            "Live continuation title",
+                            "2026-08-14T12:02:00Z",
+                            None,
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "newer-branch",
+                            "root-session",
+                            "Newer branch title",
+                            "2026-08-14T12:03:00Z",
+                            None,
+                            "desktop",
+                            json.dumps({"_branched_from": "root-session"}),
+                        ),
+                    ),
+                )
+
+            for requested_session in ("live-continuation", "root-session"):
+                with self.subTest(requested_session=requested_session):
+                    self.assertEqual(
+                        hermes_session_metadata_from_db(state_db, requested_session),
+                        ("root-session", "Live continuation title"),
+                    )
+
+    def test_hermes_lineage_excludes_branch_delegate_tool_and_reset_children(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_db = Path(tmp) / "state.db"
+            with sqlite_connection(state_db) as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        id TEXT PRIMARY KEY,
+                        parent_session_id TEXT,
+                        title TEXT,
+                        started_at TEXT,
+                        end_reason TEXT,
+                        source TEXT,
+                        model_config TEXT
+                    )
+                    """
+                )
+                connection.executemany(
+                    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        (
+                            "root-session",
+                            None,
+                            "Root chat",
+                            "2026-08-14T12:00:00Z",
+                            "compression",
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "compressed-session",
+                            "root-session",
+                            "Compressed chat",
+                            "2026-08-14T12:01:00Z",
+                            None,
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "branch-session",
+                            "root-session",
+                            "Branch chat",
+                            "2026-08-14T12:02:00Z",
+                            None,
+                            "desktop",
+                            json.dumps({"_branched_from": "root-session"}),
+                        ),
+                        (
+                            "delegate-session",
+                            "root-session",
+                            "Delegate chat",
+                            "2026-08-14T12:03:00Z",
+                            None,
+                            "desktop",
+                            json.dumps({"_delegate_from": "root-session"}),
+                        ),
+                        (
+                            "tool-session",
+                            "root-session",
+                            "Tool chat",
+                            "2026-08-14T12:04:00Z",
+                            None,
+                            "tool",
+                            None,
+                        ),
+                        (
+                            "reset-session",
+                            "root-session",
+                            "Reset chat",
+                            "2026-08-14T12:05:00Z",
+                            None,
+                            "desktop",
+                            json.dumps({"_reset_from": "root-session"}),
+                        ),
+                    ),
+                )
+
+            self.assertEqual(
+                hermes_session_metadata_from_db(state_db, "compressed-session"),
+                ("root-session", "Compressed chat"),
+            )
+            for session_id, title in (
+                ("branch-session", "Branch chat"),
+                ("delegate-session", "Delegate chat"),
+                ("tool-session", "Tool chat"),
+                ("reset-session", "Reset chat"),
+            ):
+                with self.subTest(session_id=session_id):
+                    self.assertEqual(
+                        hermes_session_metadata_from_db(state_db, session_id),
+                        (session_id, title),
+                    )
+
+    def test_hermes_session_title_updates_after_rename(self) -> None:
+        monitor = LiveAgentMonitor(stale_after_seconds=3600)
+
+        def event(title: str, logged_at: str):
+            return parse_log_line(
+                "hermes",
+                json.dumps(
+                    {
+                        "hook_event_name": "SessionActivate",
+                        "session_id": "renamed-session",
+                        "hermes_profile": "default",
+                        "integration": "hermes-plugin",
+                        "agent_id": "EDI:rename-fragment",
+                        "session_title": title,
+                        "sidepulse_status": "working",
+                        "logged_at": logged_at,
+                    }
+                ),
+            )
+
+        now = datetime.now(timezone.utc)
+        old_record = event("Old title", now.isoformat())
+        new_record = event("New title", (now + timedelta(seconds=1)).isoformat())
+        self.assertIsNotNone(old_record)
+        self.assertIsNotNone(new_record)
+        assert old_record is not None
+        assert new_record is not None
+
+        monitor.ingest_record(old_record)
+        monitor.ingest_record(new_record)
+
+        statuses = monitor.snapshot(include_stale=True).statuses
+        self.assertEqual(len(statuses), 1)
+        self.assertIn("New title", statuses[0].display_name)
+        self.assertNotIn("Old title", statuses[0].display_name)
+
+    def test_hermes_custom_profile_uses_configured_home_db(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            custom_home = Path(tmp) / "custom-hermes-home"
+            expected = custom_home / "state.db"
+
+            with patch.dict(
+                os.environ,
+                {"HERMES_HOME": str(custom_home)},
+                clear=True,
+            ):
+                paths = hermes_state_db_paths(profile_name="custom")
+
+            self.assertEqual(paths, (expected,))
+
+    def test_hermes_state_db_override_must_match_profile_selector(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root_home = Path(tmp) / "hermes-root"
+            alpha_db = root_home / "profiles" / "alpha" / "state.db"
+
+            with patch.dict(
+                os.environ,
+                {
+                    "HERMES_HOME": str(root_home),
+                    "SIDEPULSE_HERMES_STATE_DB": str(alpha_db),
+                },
+                clear=True,
+            ):
+                alpha_paths = hermes_state_db_paths(profile_name="alpha")
+                beta_paths = hermes_state_db_paths(profile_name="beta")
+
+            self.assertEqual(alpha_paths, (alpha_db,))
+            self.assertEqual(beta_paths, ())
+
+    def test_hermes_profile_selector_prevents_cross_profile_session_collision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            hermes_root = home / ".hermes"
+
+            for profile, root_id, title in (
+                ("alpha", "alpha-root", "Alpha chat"),
+                ("beta", "beta-root", "Beta chat"),
+            ):
+                state_db = hermes_root / "profiles" / profile / "state.db"
+                state_db.parent.mkdir(parents=True)
+                with sqlite_connection(state_db) as connection:
+                    connection.execute(
+                        """
+                        CREATE TABLE sessions (
+                            id TEXT PRIMARY KEY,
+                            parent_session_id TEXT,
+                            title TEXT,
+                            started_at TEXT
+                        )
+                        """
+                    )
+                    connection.executemany(
+                        "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+                        (
+                            (root_id, None, None, "2026-08-14T12:00:00Z"),
+                            (
+                                "duplicate-session",
+                                root_id,
+                                title,
+                                "2026-08-14T12:05:00Z",
+                            ),
+                        ),
+                    )
+
+            line = json.dumps(
+                {
+                    "hook_event_name": "SessionActivate",
+                    "session_id": "duplicate-session",
+                    "integration": "hermes-plugin",
+                    "agent_id": "Beta:fragment",
+                    "hermes_profile": "beta",
+                    "sidepulse_status": "working",
+                    "logged_at": "2026-08-14T12:06:00Z",
+                }
+            )
+            with (
+                patch.dict(
+                    os.environ,
+                    {"HERMES_HOME": str(hermes_root)},
+                    clear=False,
+                ),
+                patch("sidepulse.providers.Path.home", return_value=home),
+            ):
+                record = parse_log_line("hermes", line)
+
+            self.assertIsNotNone(record)
+            assert record is not None
+            self.assertEqual(record.raw.get("session_title"), "Beta chat")
+            self.assertNotEqual(record.agent_id, "Beta:fragment")
+
+    def test_unscoped_hermes_event_fails_closed_on_cross_profile_id_collision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            hermes_root = home / ".hermes"
+
+            for profile, title in (("alpha", "Alpha chat"), ("beta", "Beta chat")):
+                state_db = hermes_root / "profiles" / profile / "state.db"
+                state_db.parent.mkdir(parents=True)
+                with sqlite_connection(state_db) as connection:
+                    connection.execute(
+                        """
+                        CREATE TABLE sessions (
+                            id TEXT PRIMARY KEY,
+                            parent_session_id TEXT,
+                            title TEXT,
+                            started_at TEXT
+                        )
+                        """
+                    )
+                    connection.execute(
+                        "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+                        (
+                            "duplicate-session",
+                            None,
+                            title,
+                            "2026-08-14T12:05:00Z",
+                        ),
+                    )
+
+            line = json.dumps(
+                {
+                    "hook_event_name": "SessionActivate",
+                    "session_id": "duplicate-session",
+                    "integration": "hermes-plugin",
+                    "agent_id": "Hermes:fragment",
+                    "sidepulse_status": "working",
+                    "logged_at": "2026-08-14T12:06:00Z",
+                }
+            )
+            with (
+                patch.dict(
+                    os.environ,
+                    {"HERMES_HOME": str(hermes_root)},
+                    clear=False,
+                ),
+                patch("sidepulse.providers.Path.home", return_value=home),
+            ):
+                record = parse_log_line("hermes", line)
+
+            self.assertIsNotNone(record)
+            assert record is not None
+            self.assertNotIn("session_title", record.raw)
+            self.assertEqual(record.agent_id, "Hermes:fragment")
+
+    def test_profileless_hermes_event_does_not_search_unique_visible_database(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            hermes_root = home / ".hermes"
+            state_db = hermes_root / "profiles" / "private" / "state.db"
+            state_db.parent.mkdir(parents=True)
+            with sqlite_connection(state_db) as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        id TEXT PRIMARY KEY,
+                        parent_session_id TEXT,
+                        title TEXT,
+                        started_at TEXT
+                    )
+                    """
+                )
+                connection.execute(
+                    "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+                    (
+                        "unique-private-session",
+                        None,
+                        "Private profile conversation title",
+                        "2026-08-14T12:05:00Z",
+                    ),
+                )
+
+            line = json.dumps(
+                {
+                    "hook_event_name": "SessionActivate",
+                    "session_id": "unique-private-session",
+                    "integration": "hermes-plugin",
+                    "agent_id": "Hermes:fragment",
+                    "sidepulse_status": "working",
+                    "logged_at": "2026-08-14T12:06:00Z",
+                }
+            )
+            with (
+                patch.dict(
+                    os.environ,
+                    {"HERMES_HOME": str(hermes_root)},
+                    clear=False,
+                ),
+                patch("sidepulse.providers.Path.home", return_value=home),
+                patch(
+                    "sidepulse.providers.hermes_session_metadata_from_db",
+                    wraps=hermes_session_metadata_from_db,
+                ) as database_lookup,
+            ):
+                record = parse_log_line("hermes", line)
+
+            self.assertIsNotNone(record)
+            assert record is not None
+            database_lookup.assert_not_called()
+            self.assertNotIn("session_title", record.raw)
+            self.assertNotIn("Private profile conversation title", json.dumps(record.raw))
+            self.assertEqual(record.agent_id, "Hermes:fragment")
+            self.assertIsNone(collector_module.status_from_event(record))
+
+            monitor = LiveAgentMonitor(stale_after_seconds=3600)
+            monitor.ingest_record(record)
+            snapshot = monitor.snapshot(include_stale=True)
+            self.assertEqual(snapshot.statuses + snapshot.stale_statuses, ())
+
+    def test_hermes_status_identity_is_scoped_by_profile(self) -> None:
+        monitor = LiveAgentMonitor(stale_after_seconds=3600)
+        now = datetime.now(timezone.utc)
+        for profile, title, mode in (
+            ("alpha", "Alpha imported chat", "working"),
+            ("beta", "Beta imported chat", "waiting_for_input"),
+        ):
+            record = parse_log_line(
+                "hermes",
+                json.dumps(
+                    {
+                        "hook_event_name": "SessionActivate",
+                        "session_id": "imported-session",
+                        "agent_id": "EDI:shared-lineage-fragment",
+                        "hermes_profile": profile,
+                        "session_title": title,
+                        "sidepulse_mode": mode,
+                        "logged_at": now.isoformat(),
+                    }
+                ),
+            )
+            self.assertIsNotNone(record)
+            assert record is not None
+            monitor.ingest_record(record)
+
+        statuses = monitor.snapshot(include_stale=True).statuses
+        self.assertEqual(len(statuses), 2)
+        self.assertEqual(len({status.agent_id for status in statuses}), 2)
+        self.assertEqual(
+            {status.mode for status in statuses},
+            {AgentMode.WORKING, AgentMode.WAITING_FOR_INPUT},
+        )
+        self.assertTrue(
+            any("Alpha imported chat" in status.display_name for status in statuses)
+        )
+        self.assertTrue(
+            any("Beta imported chat" in status.display_name for status in statuses)
+        )
 
     def test_hook_payload_stamps_origin_from_vscode_environment(self) -> None:
         with patch.dict(os.environ, {"TERM_PROGRAM": "vscode"}, clear=True):
@@ -629,6 +1193,547 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(reloaded.snapshot().aggregate.mode, AgentMode.TOOL_RUNNING)
             self.assertEqual(reloaded.snapshot().statuses[0].origin, "Codex UI")
 
+    def test_latest_state_with_conversation_title_is_owner_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "agent-monitor"
+            latest = state_dir / "latest.json"
+            monitor = LiveAgentMonitor(
+                latest_state_path=latest,
+                stale_after_seconds=3600,
+            )
+            record = parse_log_line(
+                "claude",
+                json.dumps(
+                    {
+                        "hook_event_name": "UserPromptSubmit",
+                        "session_id": "private-title-session",
+                        "prompt": "Private conversation-derived title",
+                        "logged_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                ),
+            )
+            self.assertIsNotNone(record)
+            assert record is not None
+
+            previous_umask = os.umask(0)
+            try:
+                monitor.ingest_record(record)
+            finally:
+                os.umask(previous_umask)
+
+            payload = json.loads(latest.read_text(encoding="utf-8"))
+            self.assertIn(
+                "Private conversation-derived title",
+                payload["statuses"][0]["display_name"],
+            )
+            self.assertEqual(state_dir.stat().st_mode & 0o777, 0o700)
+            self.assertEqual(latest.stat().st_mode & 0o777, 0o600)
+
+    def test_hermes_startup_replay_preserves_persisted_state_without_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            latest = base / "latest.json"
+            missing_log = base / "missing-hermes.jsonl"
+            now = datetime.now(timezone.utc)
+            persisted = AgentStatus(
+                provider="hermes",
+                agent_id="hermes:agent:socket-only",
+                display_name="Socket-only Hermes session",
+                mode=AgentMode.WORKING,
+                updated_at=now,
+                event_name="SessionActivate",
+                session_id="socket-only-session",
+            )
+            latest.write_text(
+                json.dumps({"statuses": [persisted.to_dict(now)]}),
+                encoding="utf-8",
+            )
+            monitor = LiveAgentMonitor(
+                latest_state_path=latest,
+                stale_after_seconds=3600,
+            )
+
+            replayed = collector_module.replay_recent_debug_logs(
+                monitor,
+                providers=("hermes",),
+                max_lines=20,
+                detect_log_path_fn=lambda _provider: missing_log,
+            )
+
+            statuses = monitor.snapshot(include_stale=True).statuses
+            persisted_payload = json.loads(latest.read_text(encoding="utf-8"))
+            self.assertEqual(replayed, 0)
+            self.assertEqual([status.agent_id for status in statuses], [persisted.agent_id])
+            self.assertEqual(
+                [status["agent_id"] for status in persisted_payload["statuses"]],
+                [persisted.agent_id],
+            )
+
+    def test_hermes_startup_replay_preserves_unrelated_no_log_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            latest = base / "latest.json"
+            log = base / "hermes.jsonl"
+            now = datetime.now(timezone.utc)
+            stale_represented = AgentStatus(
+                provider="hermes",
+                agent_id="hermes:agent:EDI:stale-fragment",
+                display_name="Stale represented identity",
+                mode=AgentMode.BLOCKED_ERROR,
+                updated_at=now - timedelta(seconds=30),
+                event_name="SessionActivate",
+                session_id="logged-session",
+            )
+            socket_only = AgentStatus(
+                provider="hermes",
+                agent_id="hermes:agent:EDI:socket-only",
+                display_name="Socket-only no-log session",
+                mode=AgentMode.WORKING,
+                updated_at=now,
+                event_name="UserPromptSubmit",
+                session_id="socket-only-session",
+            )
+            latest.write_text(
+                json.dumps(
+                    {
+                        "statuses": [
+                            stale_represented.to_dict(now),
+                            socket_only.to_dict(now),
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            log.write_text(
+                json.dumps(
+                    {
+                        "hook_event_name": "SessionActivate",
+                        "session_id": "logged-session",
+                        "hermes_profile": "default",
+                        "agent_id": "EDI:replayed-fragment",
+                        "sidepulse_mode": "working",
+                        "logged_at": (now - timedelta(seconds=10)).isoformat(),
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            monitor = LiveAgentMonitor(
+                latest_state_path=latest,
+                stale_after_seconds=3600,
+            )
+
+            replayed = collector_module.replay_recent_debug_logs(
+                monitor,
+                providers=("hermes",),
+                max_lines=20,
+                detect_log_path_fn=lambda _provider: log,
+            )
+
+            statuses = monitor.snapshot(include_stale=True).statuses
+            by_session = {status.session_id: status for status in statuses}
+            self.assertEqual(replayed, 1)
+            self.assertEqual(set(by_session), {"logged-session", "socket-only-session"})
+            self.assertEqual(by_session["logged-session"].mode, AgentMode.WORKING)
+            self.assertNotEqual(
+                by_session["logged-session"].agent_id,
+                stale_represented.agent_id,
+            )
+            self.assertEqual(
+                by_session["socket-only-session"].agent_id,
+                socket_only.agent_id,
+            )
+
+    def test_hermes_startup_replay_does_not_replace_newer_socket_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            latest = base / "latest.json"
+            log = base / "hermes.jsonl"
+            now = datetime.now(timezone.utc)
+            socket_status = AgentStatus(
+                provider="hermes",
+                agent_id="hermes:agent:EDI:socket-fragment",
+                display_name="Newer socket state",
+                mode=AgentMode.WAITING_FOR_INPUT,
+                updated_at=now - timedelta(seconds=3),
+                event_name="PermissionRequest",
+                session_id="shared-session",
+            )
+            latest.write_text(
+                json.dumps({"statuses": [socket_status.to_dict(now)]}),
+                encoding="utf-8",
+            )
+            log.write_text(
+                json.dumps(
+                    {
+                        "hook_event_name": "SessionActivate",
+                        "session_id": "shared-session",
+                        "agent_id": "EDI:older-log-fragment",
+                        "sidepulse_mode": "working",
+                        "logged_at": (now - timedelta(seconds=30)).isoformat(),
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            monitor = LiveAgentMonitor(
+                latest_state_path=latest,
+                stale_after_seconds=3600,
+            )
+
+            replayed = collector_module.replay_recent_debug_logs(
+                monitor,
+                providers=("hermes",),
+                max_lines=20,
+                detect_log_path_fn=lambda _provider: log,
+            )
+
+            statuses = monitor.snapshot(include_stale=True).statuses
+            self.assertEqual(replayed, 0)
+            self.assertEqual(len(statuses), 1)
+            self.assertEqual(statuses[0].agent_id, socket_status.agent_id)
+            self.assertEqual(statuses[0].mode, AgentMode.WAITING_FOR_INPUT)
+
+    def test_hermes_startup_replay_is_atomic_with_newer_socket_ingestion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            log = base / "hermes.jsonl"
+            now = datetime.now(timezone.utc)
+            session_id = "atomic-replay-session"
+            log.write_text(
+                json.dumps(
+                    {
+                        "hook_event_name": "SessionActivate",
+                        "session_id": session_id,
+                        "agent_id": "EDI:shared-fragment",
+                        "hermes_profile": "default",
+                        "sidepulse_mode": "working",
+                        "logged_at": (now - timedelta(seconds=30)).isoformat(),
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            live_record = parse_log_line(
+                "hermes",
+                json.dumps(
+                    {
+                        "hook_event_name": "PermissionRequest",
+                        "session_id": session_id,
+                        "agent_id": "EDI:shared-fragment",
+                        "hermes_profile": "default",
+                        "sidepulse_mode": "waiting_for_input",
+                        "logged_at": now.isoformat(),
+                    }
+                ),
+            )
+            self.assertIsNotNone(live_record)
+            assert live_record is not None
+
+            after_prepare = threading.Barrier(2)
+            live_ingested = threading.Event()
+
+            class CoordinatedMonitor(LiveAgentMonitor):
+                def prepare_replay_records(self, provider, records):
+                    prepared = super().prepare_replay_records(provider, records)
+                    after_prepare.wait(timeout=2)
+                    live_ingested.wait(timeout=0.25)
+                    return prepared
+
+            monitor = CoordinatedMonitor(stale_after_seconds=3600)
+            replayed: list[int] = []
+            errors: list[BaseException] = []
+
+            def run_replay() -> None:
+                try:
+                    replayed.append(
+                        collector_module.replay_recent_debug_logs(
+                            monitor,
+                            providers=("hermes",),
+                            max_lines=20,
+                            detect_log_path_fn=lambda _provider: log,
+                        )
+                    )
+                except BaseException as exc:  # pragma: no cover - surfaced below
+                    errors.append(exc)
+
+            def ingest_live() -> None:
+                try:
+                    after_prepare.wait(timeout=2)
+                    monitor.ingest_record(live_record)
+                    live_ingested.set()
+                except BaseException as exc:  # pragma: no cover - surfaced below
+                    errors.append(exc)
+
+            replay_thread = threading.Thread(target=run_replay)
+            live_thread = threading.Thread(target=ingest_live)
+            replay_thread.start()
+            live_thread.start()
+            replay_thread.join(timeout=3)
+            live_thread.join(timeout=3)
+
+            self.assertFalse(replay_thread.is_alive())
+            self.assertFalse(live_thread.is_alive())
+            self.assertEqual(errors, [])
+            self.assertEqual(replayed, [1])
+            statuses = monitor.snapshot(include_stale=True).statuses
+            self.assertEqual(len(statuses), 1)
+            self.assertEqual(statuses[0].mode, AgentMode.WORKING)
+            self.assertEqual(monitor.statuses_by_key[live_record.status_key].mode, AgentMode.WAITING_FOR_INPUT)
+            self.assertEqual(statuses[0].updated_at, now)
+
+    def test_hermes_startup_replay_removes_coalesced_stale_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            hermes_home = base / ".hermes"
+            hermes_home.mkdir()
+            state_db = hermes_home / "state.db"
+            log = base / "hermes.jsonl"
+            latest = base / "latest.json"
+            now = datetime.now(timezone.utc)
+            with sqlite_connection(state_db) as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        id TEXT PRIMARY KEY,
+                        parent_session_id TEXT,
+                        title TEXT,
+                        started_at TEXT,
+                        end_reason TEXT,
+                        source TEXT,
+                        model_config TEXT
+                    )
+                    """
+                )
+                connection.executemany(
+                    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        (
+                            "lineage-root",
+                            None,
+                            "Stale root title",
+                            "2026-08-15T12:00:00Z",
+                            "compression",
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "lineage-continuation",
+                            "lineage-root",
+                            "Current continuation title",
+                            "2026-08-15T12:05:00Z",
+                            None,
+                            "desktop",
+                            None,
+                        ),
+                    ),
+                )
+            stale_ancestor = AgentStatus(
+                provider="hermes",
+                agent_id="hermes:profile:legacy:agent:EDI:stale-root",
+                display_name="Stale represented ancestor",
+                mode=AgentMode.BLOCKED_ERROR,
+                updated_at=now - timedelta(seconds=60),
+                event_name="StopFailure",
+                session_id="lineage-root",
+            )
+            unrelated = AgentStatus(
+                provider="hermes",
+                agent_id="hermes:profile:legacy:agent:EDI:unrelated",
+                display_name="Unrelated no-log state",
+                mode=AgentMode.WORKING,
+                updated_at=now,
+                event_name="UserPromptSubmit",
+                session_id="unrelated-session",
+            )
+            latest.write_text(
+                json.dumps(
+                    {
+                        "statuses": [
+                            stale_ancestor.to_dict(now),
+                            unrelated.to_dict(now),
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            replay_events = (
+                {
+                    "hook_event_name": "SessionActivate",
+                    "session_id": "lineage-root",
+                    "agent_id": "EDI:root-fragment",
+                    "hermes_profile": "default",
+                    "sidepulse_mode": "working",
+                    "logged_at": (now - timedelta(seconds=30)).isoformat(),
+                },
+                {
+                    "hook_event_name": "SessionActivate",
+                    "session_id": "lineage-continuation",
+                    "agent_id": "EDI:continuation-fragment",
+                    "hermes_profile": "default",
+                    "sidepulse_mode": "working",
+                    "logged_at": (now - timedelta(seconds=20)).isoformat(),
+                },
+            )
+            log.write_text(
+                "".join(json.dumps(event) + "\n" for event in replay_events),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"HERMES_HOME": str(hermes_home)},
+                clear=False,
+            ):
+                socket_record = parse_log_line(
+                    "hermes",
+                    json.dumps(
+                        {
+                            "hook_event_name": "PermissionRequest",
+                            "session_id": "lineage-continuation",
+                            "agent_id": "EDI:socket-fragment",
+                            "hermes_profile": "default",
+                            "sidepulse_mode": "waiting_for_input",
+                            "logged_at": now.isoformat(),
+                        }
+                    ),
+                )
+                self.assertIsNotNone(socket_record)
+                assert socket_record is not None
+                monitor = LiveAgentMonitor(
+                    latest_state_path=latest,
+                    stale_after_seconds=3600,
+                )
+                monitor.ingest_record(socket_record)
+                replayed = collector_module.replay_recent_debug_logs(
+                    monitor,
+                    providers=("hermes",),
+                    max_lines=20,
+                    detect_log_path_fn=lambda _provider: log,
+                )
+
+            snapshot = monitor.snapshot(include_stale=True)
+            statuses = snapshot.statuses + snapshot.stale_statuses
+            by_session = {status.session_id: status for status in statuses}
+            persisted = json.loads(latest.read_text(encoding="utf-8"))
+            self.assertEqual(replayed, 0)
+            self.assertEqual(
+                set(by_session),
+                {"lineage-continuation", "unrelated-session"},
+            )
+            self.assertEqual(
+                by_session["lineage-continuation"].agent_id,
+                socket_record.status_key,
+            )
+            self.assertEqual(
+                by_session["lineage-continuation"].mode,
+                AgentMode.WORKING,
+            )
+            self.assertEqual(
+                monitor.statuses_by_key[socket_record.status_key].mode,
+                AgentMode.WAITING_FOR_INPUT,
+            )
+            self.assertEqual(
+                by_session["unrelated-session"].agent_id,
+                unrelated.agent_id,
+            )
+            self.assertEqual(
+                {status["session_id"] for status in persisted["statuses"]},
+                {"lineage-continuation", "unrelated-session"},
+            )
+
+    def test_hermes_startup_replay_keeps_completion_over_boundary_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "hermes.jsonl"
+            session_id = "completed-hermes-session"
+            now = datetime.now(timezone.utc)
+            events = (
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": session_id,
+                    "hermes_profile": "default",
+                    "agent_id": "EDI:completed-fragment",
+                    "sidepulse_status": "completed",
+                    "logged_at": (now - timedelta(seconds=60)).isoformat(),
+                },
+                {
+                    "hook_event_name": "SessionStart",
+                    "session_id": session_id,
+                    "hermes_profile": "default",
+                    "agent_id": "EDI:completed-fragment",
+                    "sidepulse_status": "idle_ready",
+                    "logged_at": now.isoformat(),
+                },
+            )
+            log.write_text(
+                "\n".join(json.dumps(event) for event in events) + "\n",
+                encoding="utf-8",
+            )
+            monitor = LiveAgentMonitor(stale_after_seconds=3600)
+
+            replayed = collector_module.replay_recent_debug_logs(
+                monitor,
+                providers=("hermes",),
+                max_lines=20,
+                detect_log_path_fn=lambda _provider: log,
+            )
+
+            snapshot = monitor.snapshot(include_stale=True)
+            statuses = snapshot.statuses + snapshot.stale_statuses
+            self.assertEqual(replayed, 2)
+            self.assertEqual(len(statuses), 1)
+            self.assertEqual(statuses[0].mode, AgentMode.COMPLETED)
+            self.assertEqual(statuses[0].event_name, "Stop")
+
+            prompt = parse_log_line(
+                "hermes",
+                json.dumps(
+                    {
+                        "hook_event_name": "UserPromptSubmit",
+                        "session_id": session_id,
+                        "hermes_profile": "default",
+                        "agent_id": "EDI:completed-fragment",
+                        "sidepulse_status": "working",
+                        "logged_at": (now + timedelta(seconds=1)).isoformat(),
+                    }
+                ),
+            )
+            self.assertIsNotNone(prompt)
+            assert prompt is not None
+            monitor.ingest_record(prompt)
+            self.assertEqual(monitor.snapshot().statuses[0].mode, AgentMode.WORKING)
+
+    def test_hermes_completion_reopens_on_working_session_activation(self) -> None:
+        monitor = LiveAgentMonitor(stale_after_seconds=3600)
+        now = datetime.now(timezone.utc)
+        for event in (
+            {
+                "hook_event_name": "Stop",
+                "session_id": "reopened-session",
+                "hermes_profile": "default",
+                "agent_id": "EDI:reopened-fragment",
+                "sidepulse_mode": "completed",
+                "logged_at": now.isoformat(),
+            },
+            {
+                "hook_event_name": "SessionActivate",
+                "session_id": "reopened-session",
+                "hermes_profile": "default",
+                "agent_id": "EDI:reopened-fragment",
+                "sidepulse_mode": "working",
+                "logged_at": (now + timedelta(seconds=1)).isoformat(),
+            },
+        ):
+            record = parse_log_line("hermes", json.dumps(event))
+            self.assertIsNotNone(record)
+            assert record is not None
+            monitor.ingest_record(record)
+
+        statuses = monitor.snapshot(include_stale=True).statuses
+        self.assertEqual(len(statuses), 1)
+        self.assertEqual(statuses[0].mode, AgentMode.WORKING)
+        self.assertEqual(statuses[0].event_name, "SessionActivate")
+
     def test_status_bar_startup_replay_ingests_recent_debug_logs(self) -> None:
         try:
             from sidepulse import status_bar
@@ -669,6 +1774,122 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(replayed, 1)
             self.assertEqual(snapshot.aggregate.mode, AgentMode.WORKING)
             self.assertIn("startup replay", snapshot.statuses[0].display_name)
+
+    def test_status_bar_startup_rebuilds_persisted_hermes_lineage(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            latest = base / "latest.json"
+            log = base / "hermes.jsonl"
+            state_db = base / "state.db"
+            now = datetime.now(timezone.utc)
+
+            with sqlite_connection(state_db) as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        id TEXT PRIMARY KEY,
+                        parent_session_id TEXT,
+                        title TEXT,
+                        started_at TEXT,
+                        end_reason TEXT,
+                        source TEXT,
+                        model_config TEXT
+                    )
+                    """
+                )
+                connection.executemany(
+                    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        (
+                            "root-session",
+                            None,
+                            None,
+                            "2026-08-14T12:00:00Z",
+                            "compression",
+                            "desktop",
+                            None,
+                        ),
+                        (
+                            "compressed-session",
+                            "root-session",
+                            "Verify SidePulse after Hermes updates",
+                            "2026-08-14T12:05:00Z",
+                            None,
+                            "desktop",
+                            None,
+                        ),
+                    ),
+                )
+
+            persisted = []
+            for session_id, fragment, mode in (
+                ("root-session", "root-fragment", AgentMode.BLOCKED_ERROR),
+                ("compressed-session", "child-fragment", AgentMode.WORKING),
+            ):
+                persisted.append(
+                    AgentStatus(
+                        provider="hermes",
+                        agent_id=f"hermes:agent:EDI:{fragment}",
+                        display_name=f"Hermes agent EDI:{fragment}",
+                        mode=mode,
+                        updated_at=now,
+                        event_name="SessionActivate",
+                        session_id=session_id,
+                    ).to_dict(now)
+                )
+            latest.write_text(json.dumps({"statuses": persisted}))
+
+            lines = []
+            for session_id, fragment, status in (
+                ("root-session", "root-fragment", "blocked_error"),
+                ("compressed-session", "child-fragment", "working"),
+            ):
+                lines.append(
+                    json.dumps(
+                        {
+                            "hook_event_name": "SessionActivate",
+                            "session_id": session_id,
+                            "agent_id": f"EDI:{fragment}",
+                            "sidepulse_status": status,
+                            "logged_at": now.isoformat(),
+                        }
+                    )
+                )
+            log.write_text("\n".join(lines) + "\n")
+
+            monitor = LiveAgentMonitor(
+                latest_state_path=latest,
+                stale_after_seconds=3600,
+            )
+
+            def provider_log(provider: str) -> Path:
+                return log if provider == "hermes" else base / f"{provider}.jsonl"
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {"SIDEPULSE_HERMES_STATE_DB": str(state_db)},
+                    clear=False,
+                ),
+                patch("sidepulse.status_bar.detect_log_path", side_effect=provider_log),
+            ):
+                replayed = status_bar.replay_recent_debug_logs(monitor, max_lines=20)
+
+            snapshot = monitor.snapshot()
+            hermes_statuses = [
+                status for status in snapshot.statuses if status.provider == "hermes"
+            ]
+            self.assertEqual(replayed, 2)
+            self.assertEqual(len(hermes_statuses), 1)
+            self.assertIn(
+                "Verify SidePulse after Hermes updates",
+                hermes_statuses[0].display_name,
+            )
 
     def test_status_bar_session_menu_title_is_task_and_project(self) -> None:
         try:
@@ -1559,6 +2780,69 @@ class AgentMonitorTests(unittest.TestCase):
 
         self.assertEqual(calls, [None])
 
+    def test_status_bar_schedules_refresh_at_completion_expiry(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        scheduled: list[tuple[float, object, str, object, bool]] = []
+        timer = SimpleNamespace(invalidate=lambda: None)
+        timer_api = SimpleNamespace(
+            scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_=
+            lambda interval, target, selector, user_info, repeats: (
+                scheduled.append((interval, target, selector, user_info, repeats))
+                or timer
+            )
+        )
+        fake = SimpleNamespace(
+            current_state=status_bar.STATE_IDLE,
+            status_item=None,
+            completed_idle_timer=None,
+        )
+        fake.schedule_completed_idle_refresh = lambda: (
+            status_bar.StatusBarController.schedule_completed_idle_refresh(fake)
+        )
+        fake.cancel_completed_idle_refresh = lambda: (
+            status_bar.StatusBarController.cancel_completed_idle_refresh(fake)
+        )
+
+        with patch.object(status_bar, "NSTimer", timer_api):
+            status_bar.StatusBarController.set_status(fake, status_bar.STATE_DONE)
+
+        self.assertEqual(len(scheduled), 1)
+        self.assertAlmostEqual(
+            scheduled[0][0],
+            status_bar.COMPLETED_VISIBLE_SECONDS + 0.05,
+        )
+        self.assertEqual(scheduled[0][2], "refreshAfterCompleted:")
+        self.assertFalse(scheduled[0][4])
+
+    def test_status_bar_cancels_expiry_refresh_for_new_work(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        invalidated: list[bool] = []
+        timer = SimpleNamespace(invalidate=lambda: invalidated.append(True))
+        fake = SimpleNamespace(
+            current_state=status_bar.STATE_DONE,
+            status_item=None,
+            completed_idle_timer=timer,
+        )
+        fake.schedule_completed_idle_refresh = lambda: (
+            status_bar.StatusBarController.schedule_completed_idle_refresh(fake)
+        )
+        fake.cancel_completed_idle_refresh = lambda: (
+            status_bar.StatusBarController.cancel_completed_idle_refresh(fake)
+        )
+
+        status_bar.StatusBarController.set_status(fake, status_bar.STATE_WORKING)
+
+        self.assertEqual(invalidated, [True])
+        self.assertIsNone(fake.completed_idle_timer)
+
     def test_status_bar_sync_skips_custom_device_display(self) -> None:
         try:
             from sidepulse import status_bar
@@ -1581,7 +2865,7 @@ class AgentMonitorTests(unittest.TestCase):
             device_errors={device.device_id: "old"},
             last_led_display_kind_by_device={},
             reset_led_controllers_for_device=lambda device_id: None,
-            active_led_display_kind_for_device=lambda _device, _battery: LED_DISPLAY_CUSTOM,
+            active_led_display_kind_for_device=lambda _device, _battery, _mode: LED_DISPLAY_CUSTOM,
             agent_controller_for_device=lambda _device: self.fail("agent LEDs should not sync"),
             battery_controller_for_device=lambda _device: self.fail("battery LEDs should not sync"),
         )
@@ -1731,7 +3015,7 @@ class AgentMonitorTests(unittest.TestCase):
             ),
             last_battery_snapshot=object(),
             reset_led_controllers_for_display_change=lambda: calls.append(("reset", None)),
-            active_led_display_kind=lambda snapshot: "agent",
+            active_led_display_kind=lambda _snapshot, _mode: "agent",
             sync_leds=lambda mode, snapshot, display: calls.append(
                 ("sync", (mode, snapshot, display))
             ),
@@ -5195,10 +6479,10 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(len(snapshot.stale_statuses), 1)
             self.assertEqual(snapshot.stale_statuses[0].mode, AgentMode.COMPLETED)
 
-    def test_completed_status_stays_visible_for_twenty_minutes_by_default(self) -> None:
+    def test_completed_status_stays_visible_briefly_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "codex.jsonl"
-            recent_done = datetime.now(timezone.utc) - timedelta(minutes=19)
+            recent_done = datetime.now(timezone.utc) - timedelta(seconds=8)
             log.write_text(
                 json.dumps(
                     {
@@ -5221,6 +6505,33 @@ class AgentMonitorTests(unittest.TestCase):
 
             self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
             self.assertEqual(len(snapshot.statuses), 1)
+
+    def test_completed_status_returns_to_idle_after_brief_default_window(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "codex.jsonl"
+            recent_done = datetime.now(timezone.utc) - timedelta(seconds=20)
+            log.write_text(
+                json.dumps(
+                    {
+                        "logged_at": recent_done.isoformat(),
+                        "event": {
+                            "hook_event_name": "Stop",
+                            "session_id": "codex-session",
+                            "last_assistant_message": "Done.",
+                        },
+                    }
+                )
+                + "\n"
+            )
+
+            monitor = AgentMonitor(
+                sources=(SourceSpec("codex", log),),
+                stale_after_seconds=3600,
+            )
+            snapshot = monitor.snapshot()
+
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.IDLE_READY)
+            self.assertEqual(snapshot.statuses, ())
 
     def test_completed_status_is_hidden_when_active_work_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -5447,6 +6758,88 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
         self.assertEqual(snapshot.aggregate.active_count, 0)
         self.assertEqual(snapshot.statuses[0].event_name, "PostToolUse")
+
+    def test_hermes_post_tool_use_stays_working_while_model_thinks(self) -> None:
+        now = datetime.now(timezone.utc)
+        status = AgentStatus(
+            provider="hermes",
+            agent_id="hermes:agent:developer:abc123",
+            display_name="developer",
+            mode=AgentMode.WORKING,
+            updated_at=now
+            - timedelta(seconds=collector_module.POST_TOOL_WORKING_VISIBLE_SECONDS + 30),
+            event_name="PostToolUse",
+            session_id="hermes-session",
+            tool_name="read_file",
+        )
+
+        snapshot = collector_module.snapshot_from_statuses(
+            (status,),
+            sources=(),
+            collected_at=now,
+            stale_after_seconds=3600,
+            tool_running_timeout_seconds=0,
+            completed_visible_seconds=12,
+            idle_visible_seconds=0,
+        )
+
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.WORKING)
+        self.assertEqual(snapshot.aggregate.active_count, 1)
+
+    def test_battery_preview_does_not_override_active_agent_modes(self) -> None:
+        for mode in (
+            AgentMode.WORKING,
+            AgentMode.TOOL_RUNNING,
+            AgentMode.WAITING_FOR_INPUT,
+            AgentMode.LONG_TASK_PROGRESS,
+            AgentMode.BLOCKED_ERROR,
+        ):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    resolve_led_display_kind(
+                        "agent",
+                        battery_preview_active=True,
+                        agent_mode=mode,
+                    ),
+                    LED_DISPLAY_AGENT,
+                )
+
+    def test_battery_preview_is_allowed_when_agent_is_idle_or_completed(self) -> None:
+        for mode in (AgentMode.IDLE_READY, AgentMode.COMPLETED):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    resolve_led_display_kind(
+                        "agent",
+                        battery_preview_active=True,
+                        agent_mode=mode,
+                    ),
+                    LED_DISPLAY_BATTERY,
+                )
+
+    def test_configured_battery_or_custom_display_still_wins(self) -> None:
+        self.assertEqual(
+            resolve_led_display_kind(
+                "battery",
+                battery_preview_active=False,
+                agent_mode=AgentMode.WORKING,
+            ),
+            LED_DISPLAY_BATTERY,
+        )
+        self.assertEqual(
+            resolve_led_display_kind(
+                "custom",
+                battery_preview_active=True,
+                agent_mode=AgentMode.WORKING,
+            ),
+            LED_DISPLAY_CUSTOM,
+        )
+
+    def test_power_flap_does_not_rearm_preview_immediately(self) -> None:
+        self.assertTrue(should_arm_battery_power_preview(False, True, now=10.0, last_armed_at=None))
+        self.assertFalse(should_arm_battery_power_preview(False, True, now=20.0, last_armed_at=10.0))
+        self.assertTrue(should_arm_battery_power_preview(False, True, now=45.0, last_armed_at=10.0))
+        self.assertFalse(should_arm_battery_power_preview(None, True, now=50.0, last_armed_at=None))
+        self.assertFalse(should_arm_battery_power_preview(True, True, now=50.0, last_armed_at=None))
 
     def test_internal_codex_helper_sessions_are_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -35,6 +35,8 @@ from sidepulse.battery import (
     should_arm_battery_power_preview,
 )
 from sidepulse import collector as collector_module
+from integrations.hermes.bridge import PluginSettings as HermesPluginSettings
+from integrations.hermes.bridge import translate_hook as translate_hermes_hook
 from sidepulse import cli as cli_module
 from sidepulse.collector import (
     AgentMonitor,
@@ -293,6 +295,33 @@ class AgentMonitorTests(unittest.TestCase):
         assert status is not None
         self.assertEqual(status.mode, AgentMode.WORKING)
         self.assertEqual(status.event_name, "SessionActivate")
+
+    def test_hermes_background_review_events_are_ignored(self) -> None:
+        settings = HermesPluginSettings(agent_id="Hermes", profile_name="developer")
+        payload = {
+            "session_id": "durable-session",
+            "platform": "desktop",
+            "background_review": True,
+        }
+
+        self.assertIsNone(
+            translate_hermes_hook(
+                "pre_llm_call",
+                payload,
+                settings,
+                now="2026-08-16T12:00:00Z",
+            )
+        )
+
+        foreground_event = translate_hermes_hook(
+            "pre_llm_call",
+            {**payload, "background_review": False},
+            settings,
+            now="2026-08-16T12:00:00Z",
+        )
+        self.assertIsNotNone(foreground_event)
+        assert foreground_event is not None
+        self.assertEqual(foreground_event["hook_event_name"], "UserPromptSubmit")
 
     def test_hermes_session_finalize_is_parsed_as_completed(self) -> None:
         record = parse_log_line(

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -294,6 +294,30 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertEqual(status.mode, AgentMode.WORKING)
         self.assertEqual(status.event_name, "SessionActivate")
 
+    def test_hermes_session_finalize_is_parsed_as_completed(self) -> None:
+        record = parse_log_line(
+            "hermes",
+            json.dumps(
+                {
+                    "hook_event_name": "SessionFinalize",
+                    "session_id": "durable-session",
+                    "hermes_profile": "default",
+                    "integration": "hermes-plugin",
+                    "agent_id": "hermes:durable-session",
+                    "sidepulse_mode": "completed",
+                    "logged_at": "2026-08-16T12:01:00Z",
+                }
+            ),
+        )
+
+        self.assertIsNotNone(record)
+        assert record is not None
+        status = collector_module.status_from_event(record)
+        self.assertIsNotNone(status)
+        assert status is not None
+        self.assertEqual(status.mode, AgentMode.COMPLETED)
+        self.assertEqual(status.event_name, "SessionFinalize")
+
     def test_sessionless_hermes_tool_event_does_not_create_active_status(self) -> None:
         record = parse_log_line(
             "hermes",

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -363,6 +363,63 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertEqual(len(snapshot.statuses), 1)
         self.assertEqual(snapshot.statuses[0].event_name, "Stop")
 
+    def test_hermes_session_activation_clears_prior_agent_identity_in_same_session(self) -> None:
+        def hermes_event(event_name: str, agent_id: str, mode: str, logged_at: str):
+            return parse_log_line(
+                "hermes",
+                json.dumps(
+                    {
+                        "hook_event_name": event_name,
+                        "session_id": "same-session",
+                        "hermes_profile": "default",
+                        "integration": "hermes-plugin",
+                        "agent_id": agent_id,
+                        "sidepulse_mode": mode,
+                        "logged_at": logged_at,
+                    }
+                ),
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            latest_state_path = Path(tmp) / "latest.json"
+            monitor = LiveAgentMonitor(
+                sources=(),
+                stale_after_seconds=999999999,
+                idle_visible_seconds=999999999,
+                latest_state_path=latest_state_path,
+            )
+            active = hermes_event(
+                "UserPromptSubmit",
+                "EDI:old-agent",
+                "working",
+                "2026-08-16T12:00:00Z",
+            )
+            reopened = hermes_event(
+                "SessionActivate",
+                "EDI:new-agent",
+                "idle_ready",
+                "2026-08-16T12:00:01Z",
+            )
+
+            self.assertIsNotNone(active)
+            self.assertIsNotNone(reopened)
+            assert active is not None
+            assert reopened is not None
+            monitor.ingest_record(active)
+
+            restarted = LiveAgentMonitor(
+                sources=(),
+                stale_after_seconds=999999999,
+                idle_visible_seconds=999999999,
+                latest_state_path=latest_state_path,
+            )
+            restarted.ingest_record(reopened)
+
+            snapshot = restarted.snapshot()
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.IDLE_READY)
+            self.assertEqual(len(snapshot.statuses), 1)
+            self.assertEqual(snapshot.statuses[0].event_name, "SessionActivate")
+
     def test_sessionless_hermes_tool_event_does_not_create_active_status(self) -> None:
         record = parse_log_line(
             "hermes",


### PR DESCRIPTION
## Summary

- add a native Hermes Agent plugin backed by `ctx.register_hook()` observers for eleven lifecycle events
- add forward-compatible `on_session_activate` handling so selecting, creating, switching to, or resuming a Desktop session reasserts that session's observable state
- translate only allowlisted lifecycle metadata into SidePulse hook events and expose zero model-facing tools
- preserve Desktop/Gateway provenance across callbacks using in-memory correlation plus bounded recovery from the owner-only metadata log
- isolate concurrent Hermes sessions with opaque session-scoped status identities so one session cannot hide another session's actionable state
- keep approval failures fail-closed and prevent approval-transport surfaces from replacing the actual client origin
- add owner-only fallback logging, diagnostics, fail-soft Unix-socket delivery, installation documentation, and regression coverage

## Why

Hermes Agent users previously needed shell-hook configuration to drive SidePulse. This integration moves Hermes-specific lifecycle mapping, privacy enforcement, diagnostics, and transport behavior into SidePulse while using Hermes' native plugin API.

A later live Desktop test exposed a second gap: Hermes did not notify plugins when the user selected or attached to a session through `session.create`, warm `session.activate`, or cold `session.resume`. The companion generic Hermes contribution is https://github.com/NousResearch/hermes-agent/pull/86494. On older Hermes versions the forward-compatible hook registration remains dormant; the other ten lifecycle hooks continue to work.

The plugin emits no prompts, conversation history, tool arguments/results, or response bodies. Approval routing/session keys are never persisted. Observer and transport failures are swallowed so SidePulse cannot interrupt Hermes.

## Lifecycle mapping

| Hermes hook | SidePulse event | Resulting mode |
|---|---|---|
| `on_session_start` | `SessionStart` | idle / ready |
| `on_session_activate` | `SessionActivate` | idle when inactive; working or waiting when recoverable |
| `on_session_reset` | `SessionStart` | idle / ready |
| `pre_llm_call` | `UserPromptSubmit` | working |
| `pre_tool_call` | `PreToolUse`; `clarify` becomes `PermissionRequest` | tool-running or waiting |
| `post_tool_call` | `PostToolUse` or `PostToolUseFailure` | working or blocked |
| `pre_approval_request` | `PermissionRequest` | waiting |
| `post_approval_response` | `UserPromptSubmit` for the explicit success allowlist; otherwise `PermissionDenied` | working or blocked |
| `api_request_error` | `StopFailure` | blocked |
| `post_llm_call` | `Stop` | completed or waiting, based on the in-memory final marker |
| `on_session_end` | preserves a completed `Stop`; interrupted/failed endings reset or block | unchanged, idle, or blocked |

## Selected-session state

`on_session_activate` receives only canonical/runtime identity, platform, reason, and the backend's `running` flag.

- inactive selected session → `idle_ready`
- active selected session with no recoverable wait state → `working`
- active selected session whose recent bounded metadata indicates approval/input wait → `waiting_for_input`

Recovery is session- and agent-scoped and reads only the bounded ending of the existing metadata log. Records must carry `integration=hermes-plugin` and the exact session-scoped `agent_id`; missing or foreign provenance fails closed. Recovery does not create a global selected-session identity or inspect prompts/history.

## Privacy and session isolation

- callback payloads are rebuilt from an explicit metadata allowlist; unknown/private fields are ignored
- `session_key` is never used as a persisted session ID
- approval hooks correlate to an already-observed durable session ID only through an in-memory `turn_id → session_id` map
- approval `surface` describes the approval transport and is never treated as the Hermes client surface
- cross-registration cache misses read at most the 1 MiB ending at the observed log size and recover only normalized non-transport surfaces/modes for the same durable session ID, configured agent identity, and Hermes-plugin provenance
- per-session status identities use the configured label plus a deterministic 12-hex SHA-256 suffix of the durable session ID
- concurrent same-profile sessions therefore produce separate SidePulse status keys
- fallback JSONL logs are created/repaired with mode `0600`

## Installation

```bash
hermes plugins install \
  git+https://github.com/inteliwear/sidepulse.git#subdirectory=integrations/hermes
hermes plugins enable hermes-sidepulse
hermes plugins doctor hermes-sidepulse --ci
hermes sidepulse doctor --json
```

For local development:

```bash
hermes -p default plugins install \
  "file://$HOME/Documents/Claude/Projects/sidepulse#integrations/hermes" \
  --force --enable
```

## Validation

Final activation delta:

- isolated repository-wide suite: **183 passed**, **47 skipped**, plus **17 subtests**
- focused activation/plugin suite: **27 passed**, plus **17 subtests**
- companion Hermes affected suites against frozen upstream base `f92accd05`: **566/566 passed**
- `SessionActivate` is accepted by the normal SidePulse parser/collector path and preserves its explicit activation mode
- Ruff baseline comparison: **0 new diagnostics**; AST/manifest parsing and `git diff --check`: passed
- independent read-only exact-byte review: passed with no blocking or non-blocking findings (`48d905ddf08b16297d3b68682a332408323760e12c300c731aed43b48a6c589d`)

Earlier published integration validation remains covered by the same complete suite, including corrupt/truncated metadata, concurrent-session isolation, fail-closed approval outcomes, owner-only logging, and privacy canaries.

### Live Desktop validation

The installed candidate was backed up, atomically replaced, and exercised after restarting Hermes Desktop and SidePulse:

- `session.create` → `SessionActivate` / `idle_ready`
- warm `session.activate` → `SessionActivate` / `idle_ready`
- cold `session.resume` → `SessionActivate` / `idle_ready`
- active/running and waiting recovery are covered by focused regressions
- installed plugin files matched the reviewed source byte-for-byte
- every activation retained `Hermes Desktop` provenance and the session-scoped opaque identity
- fallback metadata logging remained owner-only and contained no prompt, history, tool argument/result, response body, credential, session key, or approval-routing fields
- SidePulse's event socket remained healthy through gateway, monitor, and Desktop restarts

## Notes

- Hermes-specific behavior remains in SidePulse; the companion Hermes change adds only a generic lifecycle boundary and bounded metadata payload.
- Existing Hermes shell-hook startup PRs are separate and are not modified by this contribution.

## Follow-up synchronization fixes

Commit `4c92c74` extends this PR with the live synchronization fixes found during Hermes Desktop validation:

- require safe Hermes profile/session provenance and fail closed on ambiguous profile-less events
- reconcile Hermes compression/session lineage without allowing stale replay to overwrite newer live state
- close Hermes SQLite metadata connections deterministically
- prevent battery power-change previews from masking active agent status
- schedule a one-shot completion-expiry refresh so Done reliably transitions to Idle instead of depending on the 15-second poll interval
- add regression coverage for multi-chat aggregation, completion-to-idle transitions, battery behavior, and resource safety

### Final verification

- **254 tests passed** with `ResourceWarning` treated as errors
- compileall and `git diff --check` passed
- `hermes sidepulse compat` passed on Hermes v0.20.1
- all 11 required hooks present; Working, Ask, and Done socket delivery verified
- the completion-expiry fix was deployed and reproduced successfully against the live macOS status-bar process

## Session finalization synchronization

Commit `25c8345` closes the remaining Hermes Desktop shutdown gap:

- register the native `on_session_finalize` lifecycle hook
- translate finalization into a session-scoped `SessionFinalize` / completed event
- allow the existing SidePulse completion-expiry timer to produce the normal Done → Idle transition when a chat is closed without a final `Stop`
- recognize the event in the SidePulse parser and clear plugin correlation maps for finalized sessions
- add registration, translation, parser, and compatibility regressions

### Current verification

- **256 tests passed** with `ResourceWarning` treated as errors
- compileall and `git diff --check` passed
- `hermes sidepulse compat` passed on Hermes v0.20.1
- **12/12 required hooks present**; Working, Ask, and Done socket delivery verified
- the synchronized runtime was deployed to the installed uv tool and the SidePulse launch agent restarted successfully
