### PR TITLE
Add Kiro provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The monitor currently supports:
 | Codex | `~/.codex/config.toml` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/codex.jsonl` |
 | Claude | `~/.claude/settings.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/claude.jsonl` |
 | Grok | `~/.grok/hooks/sidepulse.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/grok.jsonl` |
+| Kiro CLI | `~/.kiro/agents/sidepulse.json` | `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/kiro.jsonl` |
 
 #### Local reply classifier (Apple Silicon)
 
@@ -271,11 +272,11 @@ Set up this Mac explicitly after package install:
 sidepulse setup
 ```
 
-`sidepulse setup` installs or refreshes Codex, Claude, and Grok hooks, installs
+`sidepulse setup` installs or refreshes Codex, Claude, Grok, and Kiro hooks, installs
 SidePulse Pro Eject Prevention, writes the status-bar LaunchAgent, starts both helpers
 immediately, and enables them at login. This is intentionally an explicit
 command instead of a `pip install` side effect. To set up only one provider, use
-`sidepulse setup codex`, `sidepulse setup claude`, or `sidepulse setup grok`.
+`sidepulse setup codex`, `sidepulse setup claude`, `sidepulse setup grok`, or `sidepulse setup kiro`.
 To skip the status-bar app but still install hooks and SidePulse Pro Eject Prevention, use
 `sidepulse setup --no-status-bar`.
 
@@ -332,7 +333,13 @@ sidepulse agent-monitor install
 sidepulse agent-monitor install codex
 sidepulse agent-monitor install claude
 sidepulse agent-monitor install grok
+sidepulse agent-monitor install kiro
 ```
+
+Kiro CLI currently scopes hooks to agent configuration files rather than a
+universal global hook file. SidePulse installs a managed global agent named
+`sidepulse`; launch it with `kiro-cli --agent sidepulse`. The installer refuses
+to overwrite an unmanaged `~/.kiro/agents/sidepulse.json`.
 
 Each hook invokes a small, standard-library-only Python entry point. It writes
 the event to the monitor log and then makes a short best-effort local socket
@@ -433,6 +440,7 @@ sidepulse agent-monitor uninstall
 sidepulse agent-monitor uninstall codex
 sidepulse agent-monitor uninstall claude
 sidepulse agent-monitor uninstall grok
+sidepulse agent-monitor uninstall kiro
 ```
 
 Install and start the macOS status-bar app:

--- a/src/sidepulse/cli.py
+++ b/src/sidepulse/cli.py
@@ -24,10 +24,12 @@ from .install import (
     install_codex_hooks,
     install_cursor_hooks,
     install_grok_hooks,
+    install_kiro_hooks,
     uninstall_claude_hooks,
     uninstall_codex_hooks,
     uninstall_cursor_hooks,
     uninstall_grok_hooks,
+    uninstall_kiro_hooks,
 )
 from .led_status import AgentLedController, LedStatusWrite
 from .lid_sleep import (
@@ -42,6 +44,7 @@ from .providers import (
     detect_claude_config,
     detect_codex_config,
     detect_grok_config,
+    detect_kiro_config,
     detect_log_path,
     default_log_path,
 )
@@ -99,6 +102,7 @@ def build_sidepulse_parser() -> argparse.ArgumentParser:
     setup.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     setup.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     setup.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    setup.add_argument("--kiro-log", type=Path, help="Kiro JSONL log path.")
     setup.add_argument("--dry-run", action="store_true", help="Show what would change.")
     setup.add_argument(
         "--sd-eject-guard-scope",
@@ -642,20 +646,22 @@ def build_parser(prog: str = "agent-monitor") -> argparse.ArgumentParser:
     )
     status_bar.set_defaults(func=cmd_status_bar)
 
-    install = subparsers.add_parser("install", help="Install Codex, Claude, and/or Grok monitor hooks.")
+    install = subparsers.add_parser("install", help="Install supported agent monitor hooks.")
     install.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
     install.add_argument("--log-dir", type=Path, help="Directory for provider JSONL files.")
     install.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     install.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     install.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    install.add_argument("--kiro-log", type=Path, help="Kiro JSONL log path.")
     install.add_argument("--dry-run", action="store_true", help="Show what would change.")
     install.set_defaults(func=cmd_install)
 
-    uninstall = subparsers.add_parser("uninstall", help="Remove Codex, Claude, and/or Grok monitor hooks.")
+    uninstall = subparsers.add_parser("uninstall", help="Remove supported agent monitor hooks.")
     uninstall.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
     uninstall.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     uninstall.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     uninstall.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    uninstall.add_argument("--kiro-log", type=Path, help="Kiro JSONL log path.")
     uninstall.add_argument("--dry-run", action="store_true", help="Show what would change.")
     uninstall.set_defaults(func=cmd_uninstall)
 
@@ -697,10 +703,11 @@ def add_status_args(parser: argparse.ArgumentParser, include_json: bool = True) 
     parser.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
     parser.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
     parser.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    parser.add_argument("--kiro-log", type=Path, help="Kiro JSONL log path.")
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
-    configs = [detect_codex_config(), detect_claude_config(), detect_grok_config()]
+    configs = [detect_codex_config(), detect_claude_config(), detect_grok_config(), detect_kiro_config()]
     payload = {"providers": [config.to_dict() for config in configs]}
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -821,8 +828,10 @@ def install_hook_results(args: argparse.Namespace):
             results.append(install_claude_hooks(log_path=log_path, dry_run=args.dry_run))
         elif provider == "cursor":
             results.append(install_cursor_hooks(log_path=log_path, dry_run=args.dry_run))
-        else:
+        elif provider == "grok":
             results.append(install_grok_hooks(log_path=log_path, dry_run=args.dry_run))
+        else:
+            results.append(install_kiro_hooks(log_path=log_path, dry_run=args.dry_run))
     return results
 
 
@@ -849,8 +858,10 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
             results.append(uninstall_claude_hooks(log_path=log_path, dry_run=args.dry_run))
         elif provider == "cursor":
             results.append(uninstall_cursor_hooks(log_path=log_path, dry_run=args.dry_run))
-        else:
+        elif provider == "grok":
             results.append(uninstall_grok_hooks(log_path=log_path, dry_run=args.dry_run))
+        else:
+            results.append(uninstall_kiro_hooks(log_path=log_path, dry_run=args.dry_run))
 
     for result in results:
         action = "would remove" if args.dry_run and result.changed else "removed"

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -485,6 +485,7 @@ def default_sources(settings: AgentMonitorSettings | None = None) -> tuple[Sourc
     if active_settings.claude_transcripts_enabled:
         sources.append(SourceSpec(CLAUDE_TRANSCRIPT_PROVIDER, Path.home() / ".claude" / "projects"))
     sources.append(SourceSpec("grok", detect_log_path("grok")))
+    sources.append(SourceSpec("kiro", detect_log_path("kiro")))
     return unique_sources(sources)
 
 

--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -20,8 +20,11 @@ from .providers import (
     CODEX_EVENTS,
     CURSOR_EVENTS,
     GROK_EVENTS,
+    KIRO_EVENTS,
+    KIRO_MANAGED_DESCRIPTION,
     default_cursor_hook_config_path,
     default_grok_hook_config_path,
+    default_kiro_agent_config_path,
     detect_log_path,
 )
 
@@ -167,6 +170,50 @@ def install_grok_hooks(
         target_log.touch(exist_ok=True)
 
     return InstallResult("grok", config, target_log, changed, backup, dry_run)
+
+
+def install_kiro_hooks(
+    log_path: Path | None = None,
+    config_path: Path | None = None,
+    dry_run: bool = False,
+    python_executable: str | None = None,
+) -> InstallResult:
+    config = config_path or default_kiro_agent_config_path()
+    target_log = (log_path or detect_log_path("kiro")).expanduser()
+    original = config.read_text() if config.exists() else ""
+    if original:
+        try:
+            current = json.loads(original)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"refusing to overwrite invalid Kiro agent config: {config}") from exc
+        if current.get("description") != KIRO_MANAGED_DESCRIPTION:
+            raise ValueError(f"refusing to overwrite unmanaged Kiro agent config: {config}")
+    command = hook_command("kiro", target_log, python_executable)
+    event_names = {"SessionStart": "agentSpawn", "UserPromptSubmit": "userPromptSubmit", "PreToolUse": "preToolUse", "PostToolUse": "postToolUse", "Stop": "stop"}
+    hooks: dict[str, list[dict[str, Any]]] = {}
+    for event in KIRO_EVENTS:
+        entry: dict[str, Any] = {"command": command, "timeout_ms": 5000}
+        if event in {"PreToolUse", "PostToolUse"}:
+            entry["matcher"] = "*"
+        hooks[event_names[event]] = [entry]
+    new_text = json.dumps(
+        {
+            "name": "sidepulse",
+            "description": KIRO_MANAGED_DESCRIPTION,
+            "tools": ["*"],
+            "hooks": hooks,
+        },
+        indent=2,
+    ) + "\n"
+    changed = new_text != original
+    backup = None
+    if changed and not dry_run:
+        config.parent.mkdir(parents=True, exist_ok=True)
+        backup = backup_file(config) if config.exists() else None
+        config.write_text(new_text)
+        target_log.parent.mkdir(parents=True, exist_ok=True)
+        target_log.touch(exist_ok=True)
+    return InstallResult("kiro", config, target_log, changed, backup, dry_run)
 
 
 def uninstall_codex_hooks(
@@ -416,6 +463,27 @@ def remove_cursor_hook_entries(entries: list[Any]) -> list[Any]:
             )
         )
     ]
+
+
+def uninstall_kiro_hooks(
+    log_path: Path | None = None,
+    config_path: Path | None = None,
+    dry_run: bool = False,
+) -> InstallResult:
+    config = config_path or default_kiro_agent_config_path()
+    target_log = (log_path or detect_log_path("kiro")).expanduser()
+    original = config.read_text() if config.exists() else ""
+    managed = False
+    if original:
+        try:
+            managed = json.loads(original).get("description") == KIRO_MANAGED_DESCRIPTION
+        except json.JSONDecodeError:
+            pass
+    backup = None
+    if managed and not dry_run:
+        backup = backup_file(config)
+        config.unlink()
+    return InstallResult("kiro", config, target_log, managed, backup, dry_run)
 
 
 def hook_command(

--- a/src/sidepulse/models.py
+++ b/src/sidepulse/models.py
@@ -160,4 +160,5 @@ def provider_label(provider: str) -> str:
         "grok": "Grok",
         # Lowercase is the product's own spelling, and provider.title() would break it.
         "opencode": "opencode",
+        "kiro": "Kiro",
     }.get(provider, provider.title())

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -74,8 +74,11 @@ CURSOR_EVENTS = (
     "stop",
 )
 
-HOOK_PROVIDERS = ("codex", "claude", "grok", "cursor")
-KNOWN_EVENTS = tuple(dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS))
+KIRO_EVENTS = ("SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop")
+KIRO_MANAGED_DESCRIPTION = "Kiro agent with SidePulse lifecycle monitoring enabled."
+
+HOOK_PROVIDERS = ("codex", "claude", "grok", "cursor", "kiro")
+KNOWN_EVENTS = tuple(dict.fromkeys(CODEX_EVENTS + CLAUDE_EVENTS + GROK_EVENTS + KIRO_EVENTS))
 
 
 @dataclass(frozen=True)
@@ -134,6 +137,7 @@ def detect_provider_configs(home: Path | None = None) -> list[ProviderConfig]:
         detect_claude_config(home),
         detect_grok_config(home),
         detect_cursor_config(home),
+        detect_kiro_config(home),
     ]
 
 
@@ -335,6 +339,36 @@ def _paths_from_cursor_entries(entries: list[Any]) -> list[Path]:
     return paths
 
 
+def default_kiro_agent_config_path(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".kiro" / "agents" / "sidepulse.json"
+
+
+def detect_kiro_config(home: Path | None = None) -> ProviderConfig:
+    config_path = default_kiro_agent_config_path(home)
+    if not config_path.exists():
+        return ProviderConfig("kiro", config_path, False, False, (), ())
+    try:
+        data = json.loads(config_path.read_text())
+    except Exception:
+        return ProviderConfig("kiro", config_path, True, False, (), ())
+    hooks = data.get("hooks") or {}
+    events: list[str] = []
+    paths: list[Path] = []
+    if isinstance(hooks, dict):
+        for event_name, entries in hooks.items():
+            canonical = canonical_event_name(event_name)
+            if canonical not in KIRO_EVENTS or not isinstance(entries, list):
+                continue
+            events.append(canonical)
+            for entry in entries:
+                if isinstance(entry, dict) and isinstance(entry.get("command"), str):
+                    paths.extend(extract_log_paths_from_command(entry["command"]))
+    enabled = data.get("description") == KIRO_MANAGED_DESCRIPTION and bool(events)
+    return ProviderConfig(
+        "kiro", config_path, True, enabled, tuple(sorted(set(events))), _dedupe_paths(paths)
+    )
+
+
 def detect_log_path(provider: str, home: Path | None = None) -> Path:
     if provider == "codex":
         config = detect_codex_config(home)
@@ -344,6 +378,8 @@ def detect_log_path(provider: str, home: Path | None = None) -> Path:
         config = detect_grok_config(home)
     elif provider == "cursor":
         config = detect_cursor_config(home)
+    elif provider == "kiro":
+        config = detect_kiro_config(home)
     else:
         config = ProviderConfig(provider, default_log_path(provider, home), False, False, (), ())
     if config.log_paths:
@@ -442,6 +478,7 @@ def canonical_event_name(value: Any) -> str | None:
             "pre_compact": "PreCompact",
             "post_compact": "PostCompact",
             "stop_failure": "StopFailure",
+            "agent_spawn": "SessionStart",
         }
     )
     return aliases.get(normalized)
@@ -461,6 +498,8 @@ def normalize_event_payload(raw: dict[str, Any], event_name: str, logged_at: Any
     _copy_alias(normalized, "toolInput", "tool_input")
     _copy_alias(normalized, "toolResponse", "tool_response")
     _copy_alias(normalized, "lastAssistantMessage", "last_assistant_message")
+    if "last_assistant_message" not in normalized and "assistant_response" in normalized:
+        normalized["last_assistant_message"] = normalized["assistant_response"]
     _copy_alias(normalized, "notificationType", "notification_type")
     _copy_alias(normalized, "agentOrigin", "agent_origin")
     _copy_alias(normalized, "agentOriginKind", "agent_origin_kind")

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -99,9 +99,11 @@ from .install import (
     install_claude_hooks,
     install_codex_hooks,
     install_grok_hooks,
+    install_kiro_hooks,
     uninstall_claude_hooks,
     uninstall_codex_hooks,
     uninstall_grok_hooks,
+    uninstall_kiro_hooks,
 )
 from .led_status import (
     AgentLedController,
@@ -134,6 +136,7 @@ from .providers import (
     detect_claude_config,
     detect_codex_config,
     detect_grok_config,
+    detect_kiro_config,
     default_state_dir,
     parse_log_line,
 )
@@ -864,6 +867,14 @@ class StatusBarController(NSObject):
         self.update_hooks("grok", install=False)
 
     @objc.IBAction
+    def installKiroHooks_(self, _sender):
+        self.update_hooks("kiro", install=True)
+
+    @objc.IBAction
+    def uninstallKiroHooks_(self, _sender):
+        self.update_hooks("kiro", install=False)
+
+    @objc.IBAction
     def toggleCodexTranscripts_(self, sender):
         self.set_transcript_monitoring("codex", sender.state() == NSOnState)
 
@@ -1328,6 +1339,7 @@ class StatusBarController(NSObject):
         codex = detect_codex_config()
         claude = detect_claude_config()
         grok = detect_grok_config()
+        kiro = detect_kiro_config()
         set_field_value(
             self.settings_fields.get("codex_hook_status"),
             hook_status_text(codex),
@@ -1340,6 +1352,7 @@ class StatusBarController(NSObject):
             self.settings_fields.get("grok_hook_status"),
             hook_status_text(grok),
         )
+        set_field_value(self.settings_fields.get("kiro_hook_status"), hook_status_text(kiro))
         set_field_value(
             self.settings_fields.get("settings_path"),
             f"Settings: {default_settings_path()}",
@@ -1544,10 +1557,14 @@ class StatusBarController(NSObject):
                 result = install_claude_hooks()
             elif provider == "claude":
                 result = uninstall_claude_hooks()
-            elif install:
+            elif provider == "grok" and install:
                 result = install_grok_hooks()
-            else:
+            elif provider == "grok":
                 result = uninstall_grok_hooks()
+            elif install:
+                result = install_kiro_hooks()
+            else:
+                result = uninstall_kiro_hooks()
         except Exception as exc:
             self.set_settings_message(f"{provider.title()} hooks failed: {exc}")
             self.refresh_settings_window()
@@ -4193,7 +4210,12 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
     add_button(agents_tab, "Install", 400, 288, 90, 28, target, "installGrokHooks:")
     add_button(agents_tab, "Uninstall", 500, 288, 100, 28, target, "uninstallGrokHooks:")
 
-    add_separator(agents_tab, 24, 258, tab_width - 48)
+    add_label(agents_tab, "Kiro", 32, 264, 80, 22)
+    kiro_status = add_label(agents_tab, "", 130, 264, 240, 22)
+    add_button(agents_tab, "Install", 400, 260, 90, 28, target, "installKiroHooks:")
+    add_button(agents_tab, "Uninstall", 500, 260, 100, 28, target, "uninstallKiroHooks:")
+
+    add_separator(agents_tab, 24, 250, tab_width - 48)
     add_label(agents_tab, "Session Opening", 24, 224, 240, 24)
     add_label(agents_tab, "Codex", 32, 188, 100, 22)
     codex_opener = add_provider_opener_popup(agents_tab, "codex", 160, 186, target)
@@ -4415,6 +4437,7 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         "codex_hook_status": codex_status,
         "claude_hook_status": claude_status,
         "grok_hook_status": grok_status,
+        "kiro_hook_status": kiro_status,
         "debug_log_status": debug_log_status,
         "codex_session_opener": codex_opener,
         "claude_session_opener": claude_opener,

--- a/tests/test_kiro_provider.py
+++ b/tests/test_kiro_provider.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from sidepulse.install import install_kiro_hooks, uninstall_kiro_hooks
+from sidepulse.providers import KIRO_EVENTS, detect_kiro_config, parse_log_line
+
+
+class KiroProviderTests(unittest.TestCase):
+    def test_install_detect_and_uninstall_managed_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            config = home / ".kiro" / "agents" / "sidepulse.json"
+            log = home / "state" / "kiro.jsonl"
+            installed = install_kiro_hooks(config_path=config, log_path=log, python_executable="python3")
+            self.assertTrue(installed.changed)
+            data = json.loads(config.read_text())
+            self.assertIn("SidePulse lifecycle monitoring", data["description"])
+            self.assertEqual(data["tools"], ["*"])
+            self.assertEqual(set(data["hooks"]), {"agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop"})
+            self.assertEqual(set(detect_kiro_config(home).hook_events), set(KIRO_EVENTS))
+            self.assertFalse(install_kiro_hooks(config_path=config, log_path=log, python_executable="python3").changed)
+            self.assertTrue(uninstall_kiro_hooks(config_path=config, log_path=log).changed)
+            self.assertFalse(config.exists())
+
+    def test_install_refuses_unmanaged_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "sidepulse.json"
+            config.write_text('{"name": "mine"}\n')
+            with self.assertRaisesRegex(ValueError, "unmanaged Kiro agent"):
+                install_kiro_hooks(config_path=config, log_path=Path(tmp) / "kiro.jsonl")
+
+    def test_kiro_payload_aliases(self) -> None:
+        event = parse_log_line("kiro", json.dumps({"hook_event_name": "agentSpawn", "session_id": "session-1", "cwd": "/repo"}))
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(event.event_name, "SessionStart")
+        stopped = parse_log_line("kiro", json.dumps({"hook_event_name": "stop", "session_id": "session-1", "assistant_response": "Done"}))
+        self.assertIsNotNone(stopped)
+        assert stopped is not None
+        self.assertEqual(stopped.raw["last_assistant_message"], "Done")

--- a/tests/test_provider_conformance.py
+++ b/tests/test_provider_conformance.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from sidepulse.collector import mode_for_event
+from sidepulse.models import AgentMode
+from sidepulse.providers import HOOK_PROVIDERS, parse_log_line
+
+
+class ProviderConformanceTests(unittest.TestCase):
+    CASES = (("SessionStart", AgentMode.IDLE_READY), ("UserPromptSubmit", AgentMode.WORKING), ("PreToolUse", AgentMode.TOOL_RUNNING), ("PostToolUse", AgentMode.WORKING), ("Stop", AgentMode.COMPLETED))
+
+    def test_all_providers_conform_to_core_lifecycle(self) -> None:
+        for provider in HOOK_PROVIDERS:
+            for event_name, expected_mode in self.CASES:
+                with self.subTest(provider=provider, event=event_name):
+                    event = parse_log_line(provider, json.dumps({"hook_event_name": event_name, "session_id": f"{provider}-session", "cwd": "/repo", "tool_name": "shell" if "Tool" in event_name else None, "timestamp": "2026-08-15T00:00:00Z"}))
+                    self.assertIsNotNone(event)
+                    assert event is not None
+                    self.assertEqual(event.provider, provider)
+                    self.assertEqual(event.session_id, f"{provider}-session")
+                    self.assertEqual(mode_for_event(event), expected_mode)
+
+    def test_common_snake_and_camel_case_payloads_normalize_equally(self) -> None:
+        snake = parse_log_line("kiro", '{"hook_event_name":"pre_tool_use","session_id":"s","tool_name":"shell"}')
+        camel = parse_log_line("kiro", '{"hookEventName":"preToolUse","sessionId":"s","toolName":"shell"}')
+        assert snake is not None and camel is not None
+        self.assertEqual((snake.event_name, snake.session_id, snake.tool_name), (camel.event_name, camel.session_id, camel.tool_name))


### PR DESCRIPTION
## Summary

- add Kiro CLI as a first-class SidePulse provider
- install a managed global `sidepulse` Kiro agent without overwriting user-owned agents
- normalize Kiro lifecycle and tool events into SidePulse statuses
- expose Kiro through setup, doctor, status sources, and the macOS Agent Hooks UI
- add a compact shared lifecycle conformance suite for every provider on `main`

## Why

Kiro CLI supports hooks through agent configuration files rather than a universal global hook file. SidePulse therefore creates a narrowly managed global agent for `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop` events.

Closes #3.

## Usage

```sh
sidepulse agent-monitor install kiro
kiro-cli --agent sidepulse
```

## Design notes

- Kiro currently scopes hooks to agent configuration, so installation creates `~/.kiro/agents/sidepulse.json`
- the managed agent declares `tools: ["*"]`, preserving Kiro's normal tool availability while leaving permission decisions to Kiro
- the file is recognized as managed by its exact SidePulse description; an unrelated file at that path causes a safe refusal
- uninstall removes only that managed agent
- hook commands are fail-open so monitoring cannot interrupt a Kiro session

## Review focus

- generated configuration matches Kiro's five supported lifecycle hooks
- install, repeated install, collision handling, and uninstall preserve the ownership boundary
- normalized events follow the same core state transitions as providers already on `main`

This PR is independently based on `main` and does not include OpenCode or Antigravity changes.

## Validation

- full local suite: 280 tests passed, 396 subtests passed
- focused Kiro, lifecycle, and status-bar UI suite: 30 tests passed, 75 subtests passed
- generated configuration covers supported names, matchers, idempotency, managed uninstall, and collision safety
- generated `preToolUse` command executed end-to-end with stdin JSON and produced a normalized SidePulse event
- live Kiro CLI 2.18.1 turn executed `pwd` through the shell tool and produced `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop`
- SidePulse normalized the live sequence as Idle/Ready → Working → Tool Running → Working → Completed
- live monitor output displayed the Kiro session as Completed
- GitHub Actions passes on macOS with Python 3.10 and 3.12

## Compatibility note

Kiro CLI 2.18.1 did not include the documented `session_id` field in the observed hook payloads. SidePulse safely falls back to its provider-level identity, so status transitions work, but concurrent Kiro sessions without IDs cannot be distinguished from one another until Kiro supplies that field.
