### PR TITLE
Add invocation-scoped Claude monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ python3 -m pip install -e .
 sidepulse setup
 ```
 
+Monitor only one Claude Code session without installing global Claude hooks:
+
+```sh
+sidepulse uninstall claude
+sidepulse claude
+sidepulse claude --model sonnet
+```
+
+`sidepulse claude` passes every argument through to Claude Code and injects
+SidePulse hooks through Claude's invocation-scoped `--settings` option. It does
+not modify user or project settings. Other Claude sessions remain unmonitored
+after the global Claude hooks are removed.
+
 Write an LED program directly to a mounted SidePulse Pro or SidePulse Dot device:
 
 ```sh
@@ -380,11 +393,13 @@ back to the eight-LED SidePulse Pro layout if the name is unknown.
 Remove monitor hooks:
 
 ```sh
-sidepulse agent-monitor uninstall
-sidepulse agent-monitor uninstall codex
-sidepulse agent-monitor uninstall claude
-sidepulse agent-monitor uninstall grok
+sidepulse uninstall
+sidepulse uninstall codex
+sidepulse uninstall claude
+sidepulse uninstall grok
 ```
+
+The older `sidepulse agent-monitor uninstall ...` spelling remains supported.
 
 Install and start the macOS status-bar app:
 

--- a/src/sidepulse/cli.py
+++ b/src/sidepulse/cli.py
@@ -20,6 +20,7 @@ from .collector import AgentMonitor, SourceSpec, default_sources
 from .device_writer import DEFAULT_FILE_NAME, DeviceWriteError, write_led_program
 from .hook import hook_log_main
 from .install import (
+    claude_hook_settings,
     install_claude_hooks,
     install_codex_hooks,
     install_grok_hooks,
@@ -62,6 +63,10 @@ def sidepulse_main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     if args[:1] == ["agent-monitor"]:
         return main(args[1:], prog="sidepulse agent-monitor")
+    # Claude owns all arguments after the wrapper name, including unknown
+    # options and --help, so do not make argparse interpret them first.
+    if args[:1] == ["claude"]:
+        return cmd_sidepulse_claude(argparse.Namespace(claude_args=args[1:]))
 
     parser = build_sidepulse_parser()
     if not args:
@@ -111,6 +116,21 @@ def build_sidepulse_parser() -> argparse.ArgumentParser:
     )
     setup.set_defaults(func=cmd_sidepulse_setup)
 
+    claude = subparsers.add_parser(
+        "claude",
+        add_help=False,
+        help="Run one Claude session with SidePulse monitoring enabled.",
+    )
+    claude.add_argument("claude_args", nargs=argparse.REMAINDER)
+    claude.set_defaults(func=cmd_sidepulse_claude)
+
+    uninstall = subparsers.add_parser(
+        "uninstall",
+        help="Remove SidePulse agent hooks from global provider configuration.",
+    )
+    add_uninstall_arguments(uninstall)
+    uninstall.set_defaults(func=cmd_uninstall)
+
     write = subparsers.add_parser(
         "write",
         help=f"Write an LED program to {DEFAULT_FILE_NAME} on a mounted SidePulse Pro or SidePulse Dot device.",
@@ -144,6 +164,14 @@ def add_hook_log_parser(subparsers: argparse._SubParsersAction) -> None:
     hook_log.add_argument("--provider", choices=HOOK_PROVIDERS, required=True)
     hook_log.add_argument("--log", type=Path, required=True)
     hook_log.set_defaults(func=cmd_hook_log)
+
+
+def add_uninstall_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
+    parser.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
+    parser.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
+    parser.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change.")
 
 
 def add_sidepulse_status_bar_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -565,6 +593,31 @@ def cmd_sidepulse_setup(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sidepulse_claude(args: argparse.Namespace) -> int:
+    """Replace this process with one invocation-scoped, monitored Claude session."""
+    executable = shutil.which("claude")
+    if executable is None:
+        print("sidepulse claude: Claude Code is not installed or is not on PATH.", file=sys.stderr)
+        return 127
+
+    log_path = detect_log_path("claude").expanduser()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.touch(exist_ok=True)
+        settings = json.dumps(
+            claude_hook_settings(log_path),
+            separators=(",", ":"),
+        )
+        passthrough = list(args.claude_args)
+        if passthrough[:1] == ["--"]:
+            passthrough = passthrough[1:]
+        os.execv(executable, [executable, "--settings", settings, *passthrough])
+    except OSError as exc:
+        print(f"sidepulse claude: could not launch Claude Code: {exc}", file=sys.stderr)
+        return 126
+    return 0
+
+
 def print_sd_eject_guard_result(result) -> None:
     from .sd_eject_guard_launch import SD_EJECT_GUARD_DISPLAY_NAME
 
@@ -649,11 +702,7 @@ def build_parser(prog: str = "agent-monitor") -> argparse.ArgumentParser:
     install.set_defaults(func=cmd_install)
 
     uninstall = subparsers.add_parser("uninstall", help="Remove Codex, Claude, and/or Grok monitor hooks.")
-    uninstall.add_argument("provider", choices=("all", *HOOK_PROVIDERS), nargs="?", default="all")
-    uninstall.add_argument("--codex-log", type=Path, help="Codex JSONL log path.")
-    uninstall.add_argument("--claude-log", type=Path, help="Claude JSONL log path.")
-    uninstall.add_argument("--grok-log", type=Path, help="Grok JSONL log path.")
-    uninstall.add_argument("--dry-run", action="store_true", help="Show what would change.")
+    add_uninstall_arguments(uninstall)
     uninstall.set_defaults(func=cmd_uninstall)
 
     add_hook_log_parser(subparsers)

--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -104,14 +104,17 @@ def install_claude_hooks(
 
     original = json.dumps(data, sort_keys=True)
     hooks = data.setdefault("hooks", {})
-    command = hook_command("claude", target_log, python_executable)
+    scoped_hooks = claude_hook_settings(
+        target_log,
+        python_executable=python_executable,
+    )["hooks"]
 
-    for event_name in CLAUDE_EVENTS:
+    for event_name, managed_entries in scoped_hooks.items():
         entries = hooks.get(event_name, [])
         if not isinstance(entries, list):
             entries = []
         cleaned = remove_claude_hooks_for_log(entries, target_log)
-        cleaned.append({"matcher": "*", "hooks": [{"type": "command", "command": command}]})
+        cleaned.extend(managed_entries)
         hooks[event_name] = cleaned
 
     changed = json.dumps(data, sort_keys=True) != original
@@ -124,6 +127,27 @@ def install_claude_hooks(
         target_log.touch(exist_ok=True)
 
     return InstallResult("claude", config, target_log, changed, backup, dry_run)
+
+
+def claude_hook_settings(
+    log_path: Path | None = None,
+    *,
+    python_executable: str | None = None,
+) -> dict[str, Any]:
+    """Build invocation-scoped Claude settings without touching user config."""
+    target_log = (log_path or detect_log_path("claude")).expanduser()
+    command = hook_command("claude", target_log, python_executable)
+    return {
+        "hooks": {
+            event_name: [
+                {
+                    "matcher": "*",
+                    "hooks": [{"type": "command", "command": command}],
+                }
+            ]
+            for event_name in CLAUDE_EVENTS
+        }
+    }
 
 
 def install_grok_hooks(

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -46,6 +46,7 @@ from sidepulse.device_writer import (
 from sidepulse.hook import format_hook_payload, routed_hook_payload, write_hook_payload
 from sidepulse.ipc import HookEventServer, send_hook_event
 from sidepulse.install import (
+    claude_hook_settings,
     hook_command,
     install_claude_hooks,
     install_codex_hooks,
@@ -2761,6 +2762,19 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(commands, ["echo keep >> /tmp/other.log"])
             self.assertEqual(data["permissions"]["allow"], ["Bash(date)"])
 
+    def test_claude_hook_settings_builds_scoped_config_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "claude.jsonl"
+
+            settings = claude_hook_settings(log, python_executable="python3")
+
+            self.assertFalse(log.exists())
+            self.assertEqual(set(settings), {"hooks"})
+            self.assertTrue(settings["hooks"])
+            for entries in settings["hooks"].values():
+                self.assertEqual(entries[0]["matcher"], "*")
+                self.assertIn("python3", entries[0]["hooks"][0]["command"])
+
     def test_grok_uninstaller_removes_monitor_hooks_and_preserves_other_hooks(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
@@ -3059,6 +3073,51 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertEqual(codex_only.sd_eject_guard_scope, "user")
         self.assertTrue(codex_only.no_status_bar)
         self.assertTrue(codex_only.dry_run)
+
+    def test_sidepulse_top_level_uninstall_command_shape(self) -> None:
+        parser = cli_module.build_sidepulse_parser()
+
+        default = parser.parse_args(["uninstall"])
+        claude = parser.parse_args(["uninstall", "claude", "--dry-run"])
+
+        self.assertEqual(default.provider, "all")
+        self.assertIs(default.func, cli_module.cmd_uninstall)
+        self.assertEqual(claude.provider, "claude")
+        self.assertTrue(claude.dry_run)
+
+    def test_sidepulse_claude_execs_with_scoped_hook_settings(self) -> None:
+        parser = cli_module.build_sidepulse_parser()
+        args = parser.parse_args(["claude", "--", "--model", "sonnet", "hello"])
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.object(cli_module, "detect_log_path", return_value=Path(tmp) / "claude.jsonl"),
+            patch.object(cli_module.shutil, "which", return_value="/opt/bin/claude"),
+            patch.object(cli_module.os, "execv") as execv,
+        ):
+            result = cli_module.cmd_sidepulse_claude(args)
+
+        self.assertEqual(result, 0)
+        command = execv.call_args.args[1]
+        self.assertEqual(command[:2], ["/opt/bin/claude", "--settings"])
+        self.assertEqual(command[3:], ["--model", "sonnet", "hello"])
+        self.assertIn("hooks", json.loads(command[2]))
+
+    def test_sidepulse_claude_reports_missing_executable(self) -> None:
+        parser = cli_module.build_sidepulse_parser()
+        args = parser.parse_args(["claude"])
+
+        with patch.object(cli_module.shutil, "which", return_value=None):
+            result = cli_module.cmd_sidepulse_claude(args)
+
+        self.assertEqual(result, 127)
+
+    def test_sidepulse_claude_entrypoint_forwards_unknown_options(self) -> None:
+        with patch.object(cli_module, "cmd_sidepulse_claude", return_value=23) as run_claude:
+            result = cli_module.sidepulse_main(["claude", "--model", "sonnet", "--help"])
+
+        self.assertEqual(result, 23)
+        self.assertEqual(run_claude.call_args.args[0].claude_args, ["--model", "sonnet", "--help"])
 
     def test_sidepulse_setup_installs_hooks_guard_and_status_bar(self) -> None:
         parser = cli_module.build_sidepulse_parser()


### PR DESCRIPTION
## What changed

- add `sidepulse claude [args...]` for monitoring exactly one Claude Code invocation
- inject SidePulse's existing Claude lifecycle hooks through Claude's invocation-scoped `--settings` option
- replace the wrapper process with Claude so stdin, stdout, terminal signals, and exit status remain native
- add `sidepulse uninstall [all|provider]` as a discoverable top-level alias
- retain `sidepulse agent-monitor uninstall ...` for backwards compatibility
- document the opt-in workflow and add regression coverage for settings generation, passthrough arguments, missing executables, and uninstall parsing

## Why

Global hooks make every concurrent Claude session visible to SidePulse. Users who only want to monitor one selected session need an opt-in launch path that does not rewrite their persistent Claude configuration.

The existing hook uninstaller already provided the necessary reverse operation, but it was hidden under the `agent-monitor` compatibility command. The new top-level spelling makes that capability visible next to `setup`.

## Usage

```sh
sidepulse uninstall claude
sidepulse claude
sidepulse claude --model sonnet
```

All arguments after `sidepulse claude` belong to Claude Code, including unknown flags and `--help`.

## Design details

- the wrapper builds the same hook definitions used by the persistent installer, preventing the two modes from drifting
- hook settings are serialized inline and passed to Claude with `--settings`; no temporary or persistent settings file is created
- normal user and project settings continue to load through Claude's settings hierarchy
- the SidePulse JSONL destination is created before launch
- `os.execv` replaces SidePulse with the resolved Claude executable, avoiding an intermediate process that could interfere with terminal behavior
- a missing Claude executable returns 127; a launch failure returns 126 with an actionable message

## Compatibility

- existing `sidepulse setup` and `sidepulse agent-monitor uninstall` commands are unchanged
- provider-specific and all-provider uninstallation use the same existing implementation through a shared parser helper
- this PR intentionally scopes invocation wrapping to Claude because Claude officially supports per-invocation hook settings

## Validation

- `PYTHONPATH=src ~/.local/share/sidepulse/venv/bin/python -m pytest -q tests`
- 280 tests passed, 376 subtests passed
- `git diff --check`

Closes #18.
