### PR TITLE
fix: keep agent LEDs from getting stuck on green or idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,11 @@ Display rules:
 - `Show Battery on Plug/Unplug` never overrides Working, Tool Running,
   Waiting, Long Task, or Blocked. Battery preview is also debounced so a
   flapping MagSafe connection cannot keep stealing the LEDs.
-- A `PermissionRequest` shorter than two seconds is shown as Working. Hermes
-  emits that event around auto-approved `terminal` / `execute_code` calls; the
-  amber Ask pulse is reserved for an approval that actually lingers.
+- A Hermes `PermissionRequest` shorter than two seconds is shown as Working.
+  Hermes emits that event around auto-approved `terminal` / `execute_code`
+  calls; the amber Ask pulse is reserved for an approval that actually lingers.
+  Codex `PermissionRequest` stays Ask immediately and remains sticky until the
+  matching tool finishes.
 - Hermes `PostToolUseFailure` is shown as Working. A failed tool that the
   agent continues past is not a blocked LED state. Approval denials and API
   failures still use Blocked / Error.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Agent status modes:
 | Waiting for Input | The agent needs a user decision, approval, or additional context. | Slow amber pulse. |
 | Long Task Progress | A longer job has measurable progress. | Cyan rolling animation. |
 | Blocked / Error | The agent cannot continue, a tool failed, or a recoverable error needs attention. | Slow amber pulse. |
-| Completed | The agent finished successfully. | Solid green. |
+| Completed | The agent finished successfully. | Solid green for 12 seconds, then idle. |
 
 When multiple states are active, SidePulse should show the most actionable
 mode first: Blocked / Error, Waiting for Input, Tool Running, Long Task
@@ -122,6 +122,26 @@ Aggregation priority:
 | 5 | Working | Show while one or more agents are actively processing. |
 | 6 | Completed | Show briefly when the latest active agent completes successfully. |
 | 7 | Idle / Ready | Show only when all known agents are idle or no fresh agent status exists. |
+
+The device only has four LED patterns for those seven modes: dim idle pulse,
+cyan roll, amber pulse, and solid green. Working, Tool Running, and Long Task
+Progress share cyan. Waiting for Input and Blocked / Error share amber.
+
+Display rules:
+
+- Completed stays solid green for 12 seconds, then the aggregate returns to
+  Idle / Ready.
+- `Show Battery on Plug/Unplug` never overrides Working, Tool Running,
+  Waiting, Long Task, or Blocked. Battery preview is also debounced so a
+  flapping MagSafe connection cannot keep stealing the LEDs.
+- A `PermissionRequest` shorter than two seconds is shown as Working. Hermes
+  emits that event around auto-approved `terminal` / `execute_code` calls; the
+  amber Ask pulse is reserved for an approval that actually lingers.
+- Hermes `PostToolUseFailure` is shown as Working. A failed tool that the
+  agent continues past is not a blocked LED state. Approval denials and API
+  failures still use Blocked / Error.
+- Hermes `PostToolUse` stays Working while the model thinks. Codex still
+  expires a stale post-tool Working state after two minutes.
 
 Agent statuses should include a timestamp. SidePulse should ignore stale
 statuses after a short timeout so disconnected or finished agents do not hold
@@ -432,7 +452,8 @@ reconnect.
 The dropdown and Settings window can switch the LEDs between agent status and
 battery status. When agent status is selected, `Show Battery on Plug/Unplug`
 can briefly show the battery animation for seven seconds after the power source
-changes.
+changes, but only while every agent is Idle or Completed. Active agent work
+keeps the cyan or amber status animation.
 
 The Devices section also offers **Add Screen Bar**, an optional virtual
 eight-LED device. It appears as a notch-shaped status-bar overlay that covers

--- a/src/sidepulse/battery.py
+++ b/src/sidepulse/battery.py
@@ -27,6 +27,24 @@ BATTERY_HIGH_GREEN = "#00FF66"
 BATTERY_CHARGING_MINT = "#80FFC8"
 BATTERY_OFF = "#000000"
 DEFAULT_POWER_CHANGE_PREVIEW_SECONDS = 7.0
+POWER_PREVIEW_RETRIGGER_SECONDS = 30.0
+
+
+def should_arm_battery_power_preview(
+    previous_plugged: bool | None,
+    current_plugged: bool,
+    *,
+    now: float,
+    last_armed_at: float | None,
+    retrigger_seconds: float = POWER_PREVIEW_RETRIGGER_SECONDS,
+) -> bool:
+    """Ignore the first reading and rapid plugged/unplugged flaps."""
+
+    if previous_plugged is None or previous_plugged == current_plugged:
+        return False
+    if last_armed_at is None:
+        return True
+    return now - last_armed_at >= retrigger_seconds
 
 
 @dataclass(frozen=True)

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -1288,7 +1288,8 @@ def status_for_snapshot(
     ):
         return _replace_mode(status, AgentMode.COMPLETED)
     if (
-        status.mode == AgentMode.WAITING_FOR_INPUT
+        status.provider == "hermes"
+        and status.mode == AgentMode.WAITING_FOR_INPUT
         and status.event_name == "PermissionRequest"
         and status.age_seconds(now) < PERMISSION_ASK_DEBOUNCE_SECONDS
     ):

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -32,7 +32,7 @@ CLAUDE_TRANSCRIPT_MAX_LINES = 500
 TRANSCRIPT_FILE_LIST_CACHE_SECONDS = 5.0
 CLAUDE_TRANSCRIPT_MTIME_HEARTBEAT_SKEW_SECONDS = 30.0
 CODEX_SESSION_INDEX_MAX_LINES = 5000
-COMPLETED_VISIBLE_SECONDS = 20 * 60.0
+COMPLETED_VISIBLE_SECONDS = 12.0
 IDLE_VISIBLE_SECONDS = 0.0
 POST_TOOL_WORKING_VISIBLE_SECONDS = 2 * 60.0
 
@@ -1281,6 +1281,7 @@ def status_for_snapshot(
     if (
         status.mode == AgentMode.WORKING
         and status.event_name == "PostToolUse"
+        and status.provider != "hermes"
         and post_tool_working_visible_seconds >= 0
         and status.age_seconds(now) > post_tool_working_visible_seconds
     ):

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -35,6 +35,7 @@ CODEX_SESSION_INDEX_MAX_LINES = 5000
 COMPLETED_VISIBLE_SECONDS = 12.0
 IDLE_VISIBLE_SECONDS = 0.0
 POST_TOOL_WORKING_VISIBLE_SECONDS = 2 * 60.0
+PERMISSION_ASK_DEBOUNCE_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
@@ -1286,6 +1287,18 @@ def status_for_snapshot(
         and status.age_seconds(now) > post_tool_working_visible_seconds
     ):
         return _replace_mode(status, AgentMode.COMPLETED)
+    if (
+        status.mode == AgentMode.WAITING_FOR_INPUT
+        and status.event_name == "PermissionRequest"
+        and status.age_seconds(now) < PERMISSION_ASK_DEBOUNCE_SECONDS
+    ):
+        return _replace_mode(status, AgentMode.WORKING)
+    if (
+        status.provider == "hermes"
+        and status.mode == AgentMode.BLOCKED_ERROR
+        and status.event_name == "PostToolUseFailure"
+    ):
+        return _replace_mode(status, AgentMode.WORKING)
     return status
 
 

--- a/src/sidepulse/led_status.py
+++ b/src/sidepulse/led_status.py
@@ -13,6 +13,14 @@ from .device_writer import (
 )
 from .models import AgentMode
 
+ACTIVE_AGENT_MODES = {
+    AgentMode.WORKING,
+    AgentMode.TOOL_RUNNING,
+    AgentMode.WAITING_FOR_INPUT,
+    AgentMode.LONG_TASK_PROGRESS,
+    AgentMode.BLOCKED_ERROR,
+}
+
 
 class LedDisplayState(str, Enum):
     IDLE = "idle"
@@ -64,6 +72,24 @@ def display_state_for_mode(mode: AgentMode) -> LedDisplayState:
     if mode == AgentMode.COMPLETED:
         return LedDisplayState.DONE
     return LedDisplayState.IDLE
+
+
+def resolve_led_display_kind(
+    configured_display: str,
+    *,
+    battery_preview_active: bool,
+    agent_mode: AgentMode,
+) -> str:
+    """Choose agent vs battery LEDs without letting previews hide live work."""
+
+    display = str(configured_display or "agent").strip().lower()
+    if display == "custom":
+        return "custom"
+    if display == "battery":
+        return "battery"
+    if battery_preview_active and agent_mode not in ACTIVE_AGENT_MODES:
+        return "battery"
+    return "agent"
 
 
 def program_for_display_state(

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -66,6 +66,7 @@ from .battery import (
     format_watts,
     program_for_battery,
     read_battery_snapshot,
+    should_arm_battery_power_preview,
 )
 from .audit import (
     append_status_history_record,
@@ -106,6 +107,7 @@ from .led_status import (
     normalize_brightness,
     normalized_device_name,
     program_for_display_state,
+    resolve_led_display_kind,
     write_mode_to_leds,
     display_state_for_mode,
 )
@@ -386,6 +388,7 @@ class StatusBarController(NSObject):
         self.last_battery_error = None
         self.last_power_connected = None
         self.battery_preview_until = 0.0
+        self.last_battery_preview_armed_at = None
         self.current_state = STATE_IDLE
         self.led_controller = AgentLedController()
         self.battery_led_controller = BatteryLedController()
@@ -500,7 +503,10 @@ class StatusBarController(NSObject):
         self.sync_leds(
             snapshot.aggregate.mode,
             battery_snapshot,
-            self.active_led_display_kind(battery_snapshot),
+            self.active_led_display_kind(
+                battery_snapshot,
+                snapshot.aggregate.mode,
+            ),
         )
         self.status_item.setMenu_(build_menu(snapshot, state, self))
 
@@ -1372,7 +1378,10 @@ class StatusBarController(NSObject):
             self.sync_leds(
                 self.last_snapshot.aggregate.mode,
                 self.last_battery_snapshot,
-                self.active_led_display_kind(self.last_battery_snapshot),
+                self.active_led_display_kind(
+                    self.last_battery_snapshot,
+                    self.last_snapshot.aggregate.mode,
+                ),
             )
 
     def set_virtual_status_device(self, enabled: bool) -> None:
@@ -1608,15 +1617,22 @@ class StatusBarController(NSObject):
 
     def update_battery_power_preview(self, snapshot: BatterySnapshot) -> None:
         plugged = snapshot.is_plugged
-        if self.last_power_connected is not None and self.last_power_connected != plugged:
-            if self.settings.battery_show_on_power_change:
-                self.battery_preview_until = (
-                    time.monotonic()
-                    + self.settings.battery_power_change_preview_seconds
-                )
-                log_status_bar(
-                    f"battery preview power={'plugged' if plugged else 'unplugged'}"
-                )
+        now = time.monotonic()
+        if (
+            self.settings.battery_show_on_power_change
+            and should_arm_battery_power_preview(
+                self.last_power_connected,
+                plugged,
+                now=now,
+                last_armed_at=self.last_battery_preview_armed_at,
+            )
+        ):
+            self.battery_preview_until = (
+                now + self.settings.battery_power_change_preview_seconds
+            )
+            self.last_battery_preview_armed_at = now
+            state = "plugged" if plugged else "unplugged"
+            log_status_bar(f"battery preview power={state}")
         self.last_power_connected = plugged
 
     def read_mac_sleep_snapshot(self) -> MacSleepSnapshot | None:
@@ -1665,14 +1681,19 @@ class StatusBarController(NSObject):
 
         self.last_status_history_error = None
 
-    def active_led_display_kind(self, snapshot: BatterySnapshot | None) -> str:
-        if self.settings.led_display == LED_DISPLAY_CUSTOM:
-            return LED_DISPLAY_CUSTOM
-        if self.settings.led_display == LED_DISPLAY_BATTERY:
-            return LED_DISPLAY_BATTERY
-        if snapshot is not None and time.monotonic() < self.battery_preview_until:
-            return LED_DISPLAY_BATTERY
-        return LED_DISPLAY_AGENT
+    def active_led_display_kind(
+        self,
+        snapshot: BatterySnapshot | None,
+        agent_mode: AgentMode = AgentMode.IDLE_READY,
+    ) -> str:
+        return resolve_led_display_kind(
+            self.settings.led_display,
+            battery_preview_active=(
+                snapshot is not None and time.monotonic() < self.battery_preview_until
+            ),
+            agent_mode=agent_mode,
+        )
+
 
     def reset_led_controllers_for_display_change(self) -> None:
         self.led_controller.reset()
@@ -1827,14 +1848,18 @@ class StatusBarController(NSObject):
         self,
         device: StatusBarDevice,
         battery_snapshot: BatterySnapshot | None,
+        agent_mode: AgentMode = AgentMode.IDLE_READY,
     ) -> str:
-        if device.display == LED_DISPLAY_CUSTOM:
-            return LED_DISPLAY_CUSTOM
-        if device.display == LED_DISPLAY_BATTERY:
-            return LED_DISPLAY_BATTERY
-        if battery_snapshot is not None and time.monotonic() < self.battery_preview_until:
-            return LED_DISPLAY_BATTERY
-        return LED_DISPLAY_AGENT
+        if device.display in {LED_DISPLAY_CUSTOM, LED_DISPLAY_BATTERY}:
+            return device.display
+        return resolve_led_display_kind(
+            LED_DISPLAY_AGENT,
+            battery_preview_active=(
+                battery_snapshot is not None
+                and time.monotonic() < self.battery_preview_until
+            ),
+            agent_mode=agent_mode,
+        )
 
     def sync_leds(
         self,
@@ -1879,7 +1904,11 @@ class StatusBarController(NSObject):
         )
         if device is None:
             return
-        display = self.active_led_display_kind_for_device(device, battery_snapshot)
+        display = self.active_led_display_kind_for_device(
+            device,
+            battery_snapshot,
+            mode,
+        )
         if display == LED_DISPLAY_CUSTOM:
             self.virtual_status_device.hide()
             return
@@ -1937,6 +1966,7 @@ class StatusBarController(NSObject):
             device_display_kind = self.active_led_display_kind_for_device(
                 device,
                 battery_snapshot,
+                mode,
             )
             if self.last_led_display_kind_by_device.get(device.device_id) != device_display_kind:
                 self.reset_led_controllers_for_device(device.device_id)
@@ -3807,7 +3837,10 @@ def restore_led_display(target, token_value) -> None:
         target.sync_leds(
             target.last_snapshot.aggregate.mode,
             target.last_battery_snapshot,
-            target.active_led_display_kind(target.last_battery_snapshot),
+            target.active_led_display_kind(
+                target.last_battery_snapshot,
+                target.last_snapshot.aggregate.mode,
+            ),
         )
     else:
         target.refresh_(None)

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -1562,7 +1562,7 @@ class AgentMonitorTests(unittest.TestCase):
             device_errors={device.device_id: "old"},
             last_led_display_kind_by_device={},
             reset_led_controllers_for_device=lambda device_id: None,
-            active_led_display_kind_for_device=lambda _device, _battery: LED_DISPLAY_CUSTOM,
+            active_led_display_kind_for_device=lambda _device, _battery, _mode=None: LED_DISPLAY_CUSTOM,
             agent_controller_for_device=lambda _device: self.fail("agent LEDs should not sync"),
             battery_controller_for_device=lambda _device: self.fail("battery LEDs should not sync"),
         )
@@ -1712,7 +1712,7 @@ class AgentMonitorTests(unittest.TestCase):
             ),
             last_battery_snapshot=object(),
             reset_led_controllers_for_display_change=lambda: calls.append(("reset", None)),
-            active_led_display_kind=lambda snapshot: "agent",
+            active_led_display_kind=lambda snapshot, _mode=None: "agent",
             sync_leds=lambda mode, snapshot, display: calls.append(
                 ("sync", (mode, snapshot, display))
             ),

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -5538,6 +5538,73 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertFalse(should_arm_battery_power_preview(None, True, now=50.0, last_armed_at=None))
         self.assertFalse(should_arm_battery_power_preview(True, True, now=50.0, last_armed_at=None))
 
+    def test_brief_permission_request_does_not_flash_ask(self) -> None:
+        now = datetime.now(timezone.utc)
+        status = AgentStatus(
+            provider="hermes",
+            agent_id="hermes:agent:developer:ask",
+            display_name="developer",
+            mode=AgentMode.WAITING_FOR_INPUT,
+            updated_at=now - timedelta(seconds=0.4),
+            event_name="PermissionRequest",
+            session_id="hermes-session",
+        )
+        snapshot = collector_module.snapshot_from_statuses(
+            (status,),
+            sources=(),
+            collected_at=now,
+            stale_after_seconds=3600,
+            tool_running_timeout_seconds=0,
+            completed_visible_seconds=12,
+            idle_visible_seconds=0,
+        )
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.WORKING)
+
+    def test_sustained_permission_request_still_shows_ask(self) -> None:
+        now = datetime.now(timezone.utc)
+        status = AgentStatus(
+            provider="hermes",
+            agent_id="hermes:agent:developer:ask",
+            display_name="developer",
+            mode=AgentMode.WAITING_FOR_INPUT,
+            updated_at=now - timedelta(seconds=3.0),
+            event_name="PermissionRequest",
+            session_id="hermes-session",
+        )
+        snapshot = collector_module.snapshot_from_statuses(
+            (status,),
+            sources=(),
+            collected_at=now,
+            stale_after_seconds=3600,
+            tool_running_timeout_seconds=0,
+            completed_visible_seconds=12,
+            idle_visible_seconds=0,
+        )
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.WAITING_FOR_INPUT)
+
+    def test_hermes_tool_failure_does_not_hold_blocked_led(self) -> None:
+        now = datetime.now(timezone.utc)
+        status = AgentStatus(
+            provider="hermes",
+            agent_id="hermes:agent:developer:fail",
+            display_name="developer",
+            mode=AgentMode.BLOCKED_ERROR,
+            updated_at=now,
+            event_name="PostToolUseFailure",
+            session_id="hermes-session",
+            tool_name="terminal",
+        )
+        snapshot = collector_module.snapshot_from_statuses(
+            (status,),
+            sources=(),
+            collected_at=now,
+            stale_after_seconds=3600,
+            tool_running_timeout_seconds=0,
+            completed_visible_seconds=12,
+            idle_visible_seconds=0,
+        )
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.WORKING)
+
     def test_internal_codex_helper_sessions_are_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "codex.jsonl"

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -29,6 +29,7 @@ from sidepulse.battery import (
     BatterySnapshot,
     parse_ioreg_battery_plist,
     program_for_battery,
+    should_arm_battery_power_preview,
 )
 from sidepulse import collector as collector_module
 from sidepulse import cli as cli_module
@@ -66,6 +67,7 @@ from sidepulse.led_status import (
     display_state_for_mode,
     led_count_for_target,
     program_for_display_state,
+    resolve_led_display_kind,
     write_mode_to_leds,
 )
 from sidepulse.lid_sleep import (
@@ -122,6 +124,8 @@ from sidepulse.settings import (
     HISTORY_TIMEFRAME_48H_SECONDS,
     LID_ANIMATION_CLOSED,
     LID_ANIMATION_OPEN,
+    LED_DISPLAY_AGENT,
+    LED_DISPLAY_BATTERY,
     LED_DISPLAY_CUSTOM,
     SLEEP_PREVENTION_AGENTS,
     SLEEP_PREVENTION_ALWAYS,
@@ -5172,10 +5176,10 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(len(snapshot.stale_statuses), 1)
             self.assertEqual(snapshot.stale_statuses[0].mode, AgentMode.COMPLETED)
 
-    def test_completed_status_stays_visible_for_twenty_minutes_by_default(self) -> None:
+    def test_completed_status_stays_visible_briefly_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "codex.jsonl"
-            recent_done = datetime.now(timezone.utc) - timedelta(minutes=19)
+            recent_done = datetime.now(timezone.utc) - timedelta(seconds=8)
             log.write_text(
                 json.dumps(
                     {
@@ -5198,6 +5202,33 @@ class AgentMonitorTests(unittest.TestCase):
 
             self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
             self.assertEqual(len(snapshot.statuses), 1)
+
+    def test_completed_status_returns_to_idle_after_brief_default_window(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "codex.jsonl"
+            recent_done = datetime.now(timezone.utc) - timedelta(seconds=20)
+            log.write_text(
+                json.dumps(
+                    {
+                        "logged_at": recent_done.isoformat(),
+                        "event": {
+                            "hook_event_name": "Stop",
+                            "session_id": "codex-session",
+                            "last_assistant_message": "Done.",
+                        },
+                    }
+                )
+                + "\n"
+            )
+
+            monitor = AgentMonitor(
+                sources=(SourceSpec("codex", log),),
+                stale_after_seconds=3600,
+            )
+            snapshot = monitor.snapshot()
+
+            self.assertEqual(snapshot.aggregate.mode, AgentMode.IDLE_READY)
+            self.assertEqual(snapshot.statuses, ())
 
     def test_completed_status_is_hidden_when_active_work_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -5424,6 +5455,88 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertEqual(snapshot.aggregate.mode, AgentMode.COMPLETED)
         self.assertEqual(snapshot.aggregate.active_count, 0)
         self.assertEqual(snapshot.statuses[0].event_name, "PostToolUse")
+
+    def test_hermes_post_tool_use_stays_working_while_model_thinks(self) -> None:
+        now = datetime.now(timezone.utc)
+        status = AgentStatus(
+            provider="hermes",
+            agent_id="hermes:agent:developer:abc123",
+            display_name="developer",
+            mode=AgentMode.WORKING,
+            updated_at=now
+            - timedelta(seconds=collector_module.POST_TOOL_WORKING_VISIBLE_SECONDS + 30),
+            event_name="PostToolUse",
+            session_id="hermes-session",
+            tool_name="read_file",
+        )
+
+        snapshot = collector_module.snapshot_from_statuses(
+            (status,),
+            sources=(),
+            collected_at=now,
+            stale_after_seconds=3600,
+            tool_running_timeout_seconds=0,
+            completed_visible_seconds=12,
+            idle_visible_seconds=0,
+        )
+
+        self.assertEqual(snapshot.aggregate.mode, AgentMode.WORKING)
+        self.assertEqual(snapshot.aggregate.active_count, 1)
+
+    def test_battery_preview_does_not_override_active_agent_modes(self) -> None:
+        for mode in (
+            AgentMode.WORKING,
+            AgentMode.TOOL_RUNNING,
+            AgentMode.WAITING_FOR_INPUT,
+            AgentMode.LONG_TASK_PROGRESS,
+            AgentMode.BLOCKED_ERROR,
+        ):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    resolve_led_display_kind(
+                        "agent",
+                        battery_preview_active=True,
+                        agent_mode=mode,
+                    ),
+                    LED_DISPLAY_AGENT,
+                )
+
+    def test_battery_preview_is_allowed_when_agent_is_idle_or_completed(self) -> None:
+        for mode in (AgentMode.IDLE_READY, AgentMode.COMPLETED):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    resolve_led_display_kind(
+                        "agent",
+                        battery_preview_active=True,
+                        agent_mode=mode,
+                    ),
+                    LED_DISPLAY_BATTERY,
+                )
+
+    def test_configured_battery_or_custom_display_still_wins(self) -> None:
+        self.assertEqual(
+            resolve_led_display_kind(
+                "battery",
+                battery_preview_active=False,
+                agent_mode=AgentMode.WORKING,
+            ),
+            LED_DISPLAY_BATTERY,
+        )
+        self.assertEqual(
+            resolve_led_display_kind(
+                "custom",
+                battery_preview_active=True,
+                agent_mode=AgentMode.WORKING,
+            ),
+            LED_DISPLAY_CUSTOM,
+        )
+
+    def test_power_flap_does_not_rearm_preview_immediately(self) -> None:
+        self.assertTrue(should_arm_battery_power_preview(False, True, now=10.0, last_armed_at=None))
+        self.assertFalse(should_arm_battery_power_preview(False, True, now=20.0, last_armed_at=10.0))
+        self.assertTrue(should_arm_battery_power_preview(False, True, now=45.0, last_armed_at=10.0))
+        self.assertFalse(should_arm_battery_power_preview(None, True, now=50.0, last_armed_at=None))
+        self.assertFalse(should_arm_battery_power_preview(True, True, now=50.0, last_armed_at=None))
 
     def test_internal_codex_helper_sessions_are_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Bug Description

SidePulse's LEDs were unreliable during live Hermes (and other) sessions:

- a chat still running often showed solid green or dim idle
- MagSafe plug/unplug flaps kept stealing the LEDs
- Completed never returned to Idle / Ready

## Root Cause

1. Battery power-change preview overwrote agent LEDs. Battery at ~80% uses `#00FF66`, the same green as Completed.
2. Power-state flaps re-armed that 7s preview every few seconds.
3. Completed stayed visible for 20 minutes even though the product spec says "briefly."
4. Hermes only fires `pre_llm_call` once per turn, so a 2-minute `PostToolUse` timeout turned mid-turn thinking into Completed.

## Fix

- Do not let battery preview override working, tool-running, waiting, long-task, or blocked states
- Debounce power-change preview to 30 seconds
- Show Completed for 12 seconds, then Idle / Ready
- Keep Hermes `PostToolUse` in Working; Codex still expires after two minutes

## How to Verify

1. Start a long Hermes turn with tools.
2. Unplug/replug power a few times.
3. Confirm the device stays on the cyan working animation, not battery green.
4. Finish a turn and confirm a short green flash, then dim idle.

## Test Plan

- [x] Added regression tests for battery override, power-flap debounce, brief completed, and Hermes post-tool working
- [x] Existing completed/post-tool tests still pass
- [x] Manual verification on a live SidePulse Pro after restarting the status bar

## Risk Assessment

Low / Medium — LED display policy only. Configured battery-only and custom device modes are unchanged. Codex still demotes stale `PostToolUse` to completed.
