### PR TITLE
Persist keep-awake setting, expose it in the menu, and skip caffeinate on battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,15 @@ Settings can export the hook decision log as CSV or HTML. This log lives at
 `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/event-status.jsonl`
 and shows the path from provider hook event to interpreted SidePulse status.
 
+The `Keep Awake While Agents Run` menu item controls the baseline sleep
+prevention: while it is checked, SidePulse holds a `caffeinate` assertion
+whenever agents are Working / Tool Running / Progressing, plus the five-minute
+Ask / Done / Error grace period. It is on by default, persists to
+`settings.json` as `keep_awake_enabled`, and is skipped entirely while the Mac
+is running on battery so an overnight agent run cannot drain the battery. If
+the power source cannot be determined, SidePulse keeps the machine awake rather
+than silently disabling itself.
+
 The `Keep Awake With Lid Closed` menu section controls the stronger sleep
 prevention policy:
 

--- a/src/sidepulse/keep_awake.py
+++ b/src/sidepulse/keep_awake.py
@@ -13,9 +13,42 @@ from .models import AgentMode
 
 AWAKE_GRACE_SECONDS = 300.0
 SD_STATUS_READ_SECONDS = 60.0
+POWER_SOURCE_POLL_SECONDS = 30.0
 KEEPALIVE_FILE_NAME = "keepalive"
 STATUS_FILE_NAME = KEEPALIVE_FILE_NAME
 CAFFEINATE_COMMAND = ("/usr/bin/caffeinate", "-dimsu")
+PMSET_POWER_SOURCE_COMMAND = ("/usr/bin/pmset", "-g", "ps")
+
+
+def read_on_battery_power(
+    *,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    command: Sequence[str] = PMSET_POWER_SOURCE_COMMAND,
+) -> bool | None:
+    """Return True on battery, False on AC, None when the source is unknown.
+
+    Unknown is deliberately distinct from "on battery" so that a failure to read
+    the power source never silently disables keep-awake.
+    """
+    try:
+        result = runner(
+            list(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+
+    text = result.stdout or ""
+    if isinstance(text, bytes):
+        text = text.decode("utf-8", errors="replace")
+    if "'Battery Power'" in text:
+        return True
+    if "'AC Power'" in text:
+        return False
+    return None
 
 
 class KeepAwakeController:
@@ -30,6 +63,9 @@ class KeepAwakeController:
         status_reader: Callable[[Path], None] | None = None,
         status_read_async: bool = True,
         watch_current_process: bool = True,
+        skip_on_battery: bool = True,
+        on_battery_reader: Callable[[], bool | None] | None = None,
+        power_poll_seconds: float = POWER_SOURCE_POLL_SECONDS,
     ) -> None:
         self.enabled = enabled
         self.grace_seconds = grace_seconds
@@ -39,6 +75,9 @@ class KeepAwakeController:
         self.status_reader = status_reader or touch_keepalive_file
         self.status_read_async = status_read_async
         self.watch_current_process = watch_current_process
+        self.skip_on_battery = skip_on_battery
+        self.on_battery_reader = on_battery_reader or read_on_battery_power
+        self.power_poll_seconds = power_poll_seconds
         self.process = None
         self.last_mode: AgentMode | None = None
         self.holding_requested = False
@@ -47,6 +86,9 @@ class KeepAwakeController:
         self.last_status_read_monotonic_by_path: dict[Path, float] = {}
         self.last_status_error: str | None = None
         self.status_read_in_flight_by_path: set[Path] = set()
+        self.on_battery: bool | None = None
+        self.last_power_read_monotonic: float | None = None
+        self.deferred_for_battery = False
 
     def set_enabled(self, enabled: bool) -> None:
         if self.enabled == enabled:
@@ -67,11 +109,31 @@ class KeepAwakeController:
         self.last_mode = mode
 
         if not self.enabled or not should_hold:
+            self.deferred_for_battery = False
             self.release()
             return False
 
+        if self.skip_on_battery and self.read_power_source(current) is True:
+            self.deferred_for_battery = True
+            self.release()
+            return False
+
+        self.deferred_for_battery = False
         self.ensure_awake()
         return self.process_running()
+
+    def read_power_source(self, now: float) -> bool | None:
+        """Cached power-source read; the subprocess runs at most once per poll window."""
+        last = self.last_power_read_monotonic
+        if last is not None and now - last < self.power_poll_seconds:
+            return self.on_battery
+
+        self.last_power_read_monotonic = now
+        try:
+            self.on_battery = self.on_battery_reader()
+        except Exception:
+            self.on_battery = None
+        return self.on_battery
 
     def should_hold_for_mode(self, mode: AgentMode, now: float) -> bool:
         if mode in {
@@ -174,6 +236,8 @@ class KeepAwakeController:
             return "Keep awake disabled"
         if self.last_error:
             return f"Keep awake error: {self.last_error}"
+        if self.deferred_for_battery:
+            return "Keep awake paused on battery"
         current = time.monotonic() if now is None else now
         if self.grace_until_monotonic is not None and current < self.grace_until_monotonic:
             remaining = int(self.grace_until_monotonic - current)

--- a/src/sidepulse/settings.py
+++ b/src/sidepulse/settings.py
@@ -116,6 +116,7 @@ class AgentMonitorSettings:
     led_display: str = LED_DISPLAY_AGENT
     devices: tuple[DeviceDisplaySetting, ...] = ()
     virtual_status_device_enabled: bool = False
+    keep_awake_enabled: bool = True
     closed_lid_awake_policy: str = CLOSED_LID_AWAKE_NEVER
     closed_lid_system_override_enabled: bool = False
     lid_closed_animation: LedAnimationSetting = field(
@@ -374,6 +375,9 @@ class AgentMonitorSettings:
             raise ValueError(f"Unknown closed-lid awake policy: {policy}")
         return replace(self, closed_lid_awake_policy=policy)
 
+    def with_keep_awake_enabled(self, enabled: bool) -> "AgentMonitorSettings":
+        return replace(self, keep_awake_enabled=bool(enabled))
+
     def with_closed_lid_system_override(self, enabled: bool) -> "AgentMonitorSettings":
         return replace(self, closed_lid_system_override_enabled=bool(enabled))
 
@@ -423,6 +427,7 @@ class AgentMonitorSettings:
             "led_display": self.led_display,
             "devices": [device.to_dict() for device in self.devices],
             "virtual_status_device_enabled": self.virtual_status_device_enabled,
+            "keep_awake_enabled": self.keep_awake_enabled,
             "closed_lid_awake_policy": self.closed_lid_awake_policy,
             "closed_lid_system_override_enabled": self.closed_lid_system_override_enabled,
             "lid_closed_animation": self.lid_closed_animation.to_dict(),
@@ -514,6 +519,7 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
         virtual_status_device_enabled=_bool_setting(
             data.get("virtual_status_device_enabled"), False
         ),
+        keep_awake_enabled=_bool_setting(data.get("keep_awake_enabled"), True),
         closed_lid_awake_policy=_closed_lid_awake_policy(
             data.get("closed_lid_awake_policy"),
         ),

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -159,6 +159,7 @@ from .settings import (
     TERMINAL_APP_CHOICES,
     TERMINAL_APP_WARP,
     TERMINAL_APP_WEZTERM,
+    AgentMonitorSettings,
     LedAnimationSetting,
     default_settings_path,
     default_lid_animation,
@@ -303,6 +304,15 @@ def replay_recent_debug_logs(
     return replayed
 
 
+def build_keep_awake_controller(settings: AgentMonitorSettings) -> KeepAwakeController:
+    """Build the keep-awake controller from persisted settings.
+
+    Kept module-level so the wiring between settings and controller is testable
+    without instantiating the Objective-C status bar controller.
+    """
+    return KeepAwakeController(enabled=settings.keep_awake_enabled)
+
+
 class StatusBarController(NSObject):
     def init(self):
         self = objc.super(StatusBarController, self).init()
@@ -339,7 +349,7 @@ class StatusBarController(NSObject):
         self.last_led_error = None
         self.last_led_display_kind = LED_DISPLAY_AGENT
         self.last_connected_device_signature = None
-        self.keep_awake = KeepAwakeController()
+        self.keep_awake = build_keep_awake_controller(self.settings)
         self.closed_lid_awake = ClosedLidAwakeController(
             use_system_disable=sleep_helper_installed(),
         )
@@ -532,9 +542,7 @@ class StatusBarController(NSObject):
 
     @objc.IBAction
     def toggleKeepAwake_(self, _sender):
-        self.keep_awake.set_enabled(not self.keep_awake.enabled)
-        log_status_bar(f"keep_awake={'on' if self.keep_awake.enabled else 'off'}")
-        self.refresh_(None)
+        self.set_keep_awake_enabled(not self.keep_awake.enabled)
 
     @objc.IBAction
     def setClosedLidAwakePolicy_(self, sender):
@@ -1248,6 +1256,23 @@ class StatusBarController(NSObject):
             self.virtual_status_device.show()
         else:
             self.virtual_status_device.hide()
+        self.refresh_(None)
+
+    def set_keep_awake_enabled(self, enabled: bool) -> None:
+        enabled = bool(enabled)
+        previous = self.settings
+        try:
+            self.settings = self.settings.with_keep_awake_enabled(enabled)
+            save_settings(self.settings)
+        except Exception as exc:
+            self.set_settings_message(f"Could not save keep awake setting: {exc}")
+            self.settings = previous
+            return
+
+        self.keep_awake.set_enabled(enabled)
+        self.set_settings_message(f"Keep awake: {'on' if enabled else 'off'}.")
+        log_status_bar(f"keep_awake={'on' if enabled else 'off'}")
+        self.refresh_settings_window()
         self.refresh_(None)
 
     def set_closed_lid_awake_policy(self, policy: str | None) -> None:
@@ -2056,6 +2081,15 @@ def build_menu(snapshot, state: StatusBarState, target: StatusBarController) -> 
         menu.addItem_(virtual_toggle)
 
     menu.addItem_(NSMenuItem.separatorItem())
+    keep_awake_toggle = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+        "Keep Awake While Agents Run",
+        "toggleKeepAwake:",
+        "",
+    )
+    keep_awake_toggle.setTarget_(target)
+    keep_awake_toggle.setState_(1 if target.settings.keep_awake_enabled else 0)
+    menu.addItem_(keep_awake_toggle)
+
     menu.addItem_(disabled_menu_item("Keep Awake With Lid Closed"))
     for policy in CLOSED_LID_AWAKE_CHOICES:
         menu.addItem_(build_closed_lid_awake_policy_item(policy, target))

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -55,7 +55,11 @@ from sidepulse.install import (
     uninstall_grok_hooks,
     update_codex_trusted_hashes,
 )
-from sidepulse.keep_awake import KeepAwakeController, status_file_for_target
+from sidepulse.keep_awake import (
+    KeepAwakeController,
+    read_on_battery_power,
+    status_file_for_target,
+)
 from sidepulse.led_status import (
     AgentLedController,
     LedDisplayState,
@@ -3521,6 +3525,7 @@ class AgentMonitorTests(unittest.TestCase):
         controller = KeepAwakeController(
             grace_seconds=300,
             process_factory=factory,
+            on_battery_reader=lambda: False,
         )
 
         self.assertTrue(controller.update(AgentMode.WORKING, now=100))
@@ -3548,6 +3553,7 @@ class AgentMonitorTests(unittest.TestCase):
         controller = KeepAwakeController(
             grace_seconds=300,
             process_factory=factory,
+            on_battery_reader=lambda: False,
         )
 
         self.assertTrue(controller.update(AgentMode.WAITING_FOR_INPUT, now=100))
@@ -3581,6 +3587,270 @@ class AgentMonitorTests(unittest.TestCase):
                 status_path,
             )
             self.assertEqual(reads, [status_path, status_path])
+
+    def test_keep_awake_enabled_defaults_true(self) -> None:
+        self.assertTrue(AgentMonitorSettings().keep_awake_enabled)
+
+    def test_keep_awake_enabled_round_trips_through_settings_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "settings.json"
+
+            save_settings(AgentMonitorSettings().with_keep_awake_enabled(False), path)
+            self.assertFalse(load_settings(path).keep_awake_enabled)
+
+            save_settings(load_settings(path).with_keep_awake_enabled(True), path)
+            self.assertTrue(load_settings(path).keep_awake_enabled)
+
+    def test_keep_awake_enabled_defaults_true_when_key_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "settings.json"
+            path.write_text(json.dumps({"led_display": "agent"}))
+
+            self.assertTrue(load_settings(path).keep_awake_enabled)
+
+    def test_keep_awake_skips_caffeinate_on_battery_power(self) -> None:
+        processes: list[FakeProcess] = []
+
+        def factory(*_args, **_kwargs):
+            process = FakeProcess()
+            processes.append(process)
+            return process
+
+        controller = KeepAwakeController(
+            process_factory=factory,
+            on_battery_reader=lambda: True,
+        )
+
+        self.assertFalse(controller.update(AgentMode.WORKING, now=100))
+        self.assertEqual(processes, [])
+        self.assertIn("battery", controller.detail(now=100).lower())
+
+    def test_keep_awake_holds_on_ac_power(self) -> None:
+        processes: list[FakeProcess] = []
+
+        def factory(*_args, **_kwargs):
+            process = FakeProcess()
+            processes.append(process)
+            return process
+
+        controller = KeepAwakeController(
+            process_factory=factory,
+            on_battery_reader=lambda: False,
+        )
+
+        self.assertTrue(controller.update(AgentMode.WORKING, now=100))
+        self.assertEqual(len(processes), 1)
+
+    def test_keep_awake_releases_when_power_switches_to_battery(self) -> None:
+        processes: list[FakeProcess] = []
+        on_battery = [False]
+
+        def factory(*_args, **_kwargs):
+            process = FakeProcess()
+            processes.append(process)
+            return process
+
+        controller = KeepAwakeController(
+            process_factory=factory,
+            on_battery_reader=lambda: on_battery[0],
+            power_poll_seconds=30,
+        )
+
+        self.assertTrue(controller.update(AgentMode.WORKING, now=100))
+        on_battery[0] = True
+        self.assertFalse(controller.update(AgentMode.WORKING, now=200))
+        self.assertTrue(processes[0].terminated)
+
+    def test_keep_awake_caches_power_source_between_polls(self) -> None:
+        reads: list[float] = []
+
+        def reader() -> bool:
+            reads.append(1.0)
+            return False
+
+        controller = KeepAwakeController(
+            process_factory=lambda *_a, **_k: FakeProcess(),
+            on_battery_reader=reader,
+            power_poll_seconds=30,
+        )
+
+        controller.update(AgentMode.WORKING, now=100)
+        controller.update(AgentMode.WORKING, now=110)
+        controller.update(AgentMode.WORKING, now=125)
+        self.assertEqual(len(reads), 1)
+
+        controller.update(AgentMode.WORKING, now=131)
+        self.assertEqual(len(reads), 2)
+
+    def test_keep_awake_battery_guard_can_be_disabled(self) -> None:
+        processes: list[FakeProcess] = []
+
+        def factory(*_args, **_kwargs):
+            process = FakeProcess()
+            processes.append(process)
+            return process
+
+        controller = KeepAwakeController(
+            process_factory=factory,
+            on_battery_reader=lambda: True,
+            skip_on_battery=False,
+        )
+
+        self.assertTrue(controller.update(AgentMode.WORKING, now=100))
+        self.assertEqual(len(processes), 1)
+
+    def test_keep_awake_holds_when_power_source_is_unknown(self) -> None:
+        processes: list[FakeProcess] = []
+
+        def factory(*_args, **_kwargs):
+            process = FakeProcess()
+            processes.append(process)
+            return process
+
+        controller = KeepAwakeController(
+            process_factory=factory,
+            on_battery_reader=lambda: None,
+        )
+
+        self.assertTrue(controller.update(AgentMode.WORKING, now=100))
+        self.assertEqual(len(processes), 1)
+
+    def test_read_on_battery_power_parses_pmset_output(self) -> None:
+        def runner_for(text: str):
+            def runner(*_args, **_kwargs):
+                return subprocess.CompletedProcess([], 0, stdout=text, stderr="")
+
+            return runner
+
+        battery_text = (
+            "Now drawing from 'Battery Power'\n"
+            " -InternalBattery-0 (id=7340131)\t84%; discharging; 2:11 remaining present: true\n"
+        )
+        ac_text = (
+            "Now drawing from 'AC Power'\n"
+            " -InternalBattery-0 (id=7340131)\t84%; charging; 0:21 remaining present: true\n"
+        )
+
+        self.assertTrue(read_on_battery_power(runner=runner_for(battery_text)))
+        self.assertFalse(read_on_battery_power(runner=runner_for(ac_text)))
+        self.assertIsNone(read_on_battery_power(runner=runner_for("gibberish\n")))
+
+    def test_read_on_battery_power_returns_none_when_command_fails(self) -> None:
+        def runner(*_args, **_kwargs):
+            raise OSError("boom")
+
+        self.assertIsNone(read_on_battery_power(runner=runner))
+
+    def test_build_keep_awake_controller_honours_persisted_setting(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        disabled = status_bar.build_keep_awake_controller(
+            AgentMonitorSettings().with_keep_awake_enabled(False)
+        )
+        self.assertFalse(disabled.enabled)
+
+        enabled = status_bar.build_keep_awake_controller(AgentMonitorSettings())
+        self.assertTrue(enabled.enabled)
+
+    def test_status_bar_keep_awake_toggle_persists_to_settings(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        saved: dict[str, object] = {}
+        target = SimpleNamespace(
+            settings=AgentMonitorSettings(),
+            keep_awake=KeepAwakeController(
+                enabled=True,
+                on_battery_reader=lambda: False,
+            ),
+            set_settings_message=lambda _message: None,
+            refresh_settings_window=lambda: None,
+            refresh_=lambda _sender: None,
+        )
+
+        with patch.object(
+            status_bar,
+            "save_settings",
+            lambda settings: saved.update(settings.to_dict()),
+        ):
+            status_bar.StatusBarController.set_keep_awake_enabled(target, False)
+
+        self.assertFalse(target.settings.keep_awake_enabled)
+        self.assertFalse(target.keep_awake.enabled)
+        self.assertIs(saved["keep_awake_enabled"], False)
+
+    def test_status_bar_keep_awake_toggle_reverts_settings_when_save_fails(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        messages: list[str] = []
+        target = SimpleNamespace(
+            settings=AgentMonitorSettings(),
+            keep_awake=KeepAwakeController(
+                enabled=True,
+                on_battery_reader=lambda: False,
+            ),
+            set_settings_message=messages.append,
+            refresh_settings_window=lambda: None,
+            refresh_=lambda _sender: None,
+        )
+
+        def boom(_settings):
+            raise OSError("disk full")
+
+        with patch.object(status_bar, "save_settings", boom), patch.object(
+            status_bar, "load_settings", lambda: AgentMonitorSettings()
+        ):
+            status_bar.StatusBarController.set_keep_awake_enabled(target, False)
+
+        self.assertTrue(target.settings.keep_awake_enabled)
+        self.assertTrue(target.keep_awake.enabled)
+        self.assertTrue(any("disk full" in message for message in messages))
+
+    def test_status_bar_menu_exposes_keep_awake_toggle(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        snapshot = SimpleNamespace(
+            statuses=[],
+            collected_at=datetime.now(timezone.utc),
+        )
+        target = SimpleNamespace(
+            settings=AgentMonitorSettings().with_keep_awake_enabled(True),
+            closed_lid_awake=SimpleNamespace(last_error=None),
+            status_bar_devices=lambda: [],
+        )
+
+        menu = status_bar.build_menu(snapshot, status_bar.STATE_IDLE, target)
+        item = next(
+            (
+                menu.itemAtIndex_(index)
+                for index in range(menu.numberOfItems())
+                if menu.itemAtIndex_(index).action() == "toggleKeepAwake:"
+            ),
+            None,
+        )
+
+        self.assertIsNotNone(item)
+        self.assertEqual(item.state(), 1)
+
+        target.settings = target.settings.with_keep_awake_enabled(False)
+        menu = status_bar.build_menu(snapshot, status_bar.STATE_IDLE, target)
+        item = next(
+            menu.itemAtIndex_(index)
+            for index in range(menu.numberOfItems())
+            if menu.itemAtIndex_(index).action() == "toggleKeepAwake:"
+        )
+        self.assertEqual(item.state(), 0)
 
     def test_closed_lid_awake_policy_decisions(self) -> None:
         self.assertFalse(


### PR DESCRIPTION
## The bug

`KeepAwakeController.enabled` had no persistence and no UI.

- `status_bar.py` constructed it as a bare `KeepAwakeController()`, which defaults to `enabled=True` (`keep_awake.py:25`). It was never read from `settings.json`.
- `AgentMonitorSettings` had no `keep_awake_enabled` field at all — `grep -n keep_awake src/sidepulse/settings.py` returned nothing.
- `toggleKeepAwake_` mutated the in-memory attribute and logged it, but never called `save_settings()`. Any change reverted on the next launch.
- `toggleKeepAwake_` was never wired to a menu item, so there was no way to reach it in the first place.

The only user-visible control was `Keep Awake With Lid Closed`, which drives the *separate* `ClosedLidAwakeController`. Setting that to `never` correctly disables the `pmset disablesleep` escalation, but leaves the `caffeinate -dimsu` path completely untouched — `sync_keep_awake()` runs on every snapshot with no lid or policy check.

Net effect: SidePulse holds `caffeinate -dimsu` (display, idle, disk, system sleep, plus declare-user-active) whenever agents are active, on every install, with no way to turn it off and no memory of you trying.

### Observed impact

On a MacBook Pro left on battery overnight with agents running, `pmset -g log` shows the assertion held in ~80-minute blocks through the night:

```
21:07 -> 22:27   PreventSystemSleep  1h19m
02:37 -> 04:00   PreventSystemSleep  1h22m
05:51 -> 07:11   PreventSystemSleep  ~1h20m
```

Battery went 54% -> 25% between 21:07 and 09:26 (~2.4%/hour, roughly 10x a healthy sleeping M-series Mac).

## The fix

**Persistence**
- `keep_awake_enabled: bool = True` added to `AgentMonitorSettings`, with `with_keep_awake_enabled()`, `to_dict()`, and loader support. Default stays `True`, so existing behavior is unchanged for anyone who wants it.
- New module-level `build_keep_awake_controller(settings)` so the settings-to-controller wiring is testable without instantiating the Objective-C controller.
- New `StatusBarController.set_keep_awake_enabled()` mirroring `set_closed_lid_awake_policy()`: persists, reverts cleanly on save failure, and syncs the controller.
- `toggleKeepAwake_` now delegates to it.

**Reachability**
- Added a `Keep Awake While Agents Run` checkbox menu item, above the existing lid-closed section, with state reflecting the persisted setting.

**Battery guard**
- New `read_on_battery_power()` parses `pmset -g ps`.
- `KeepAwakeController` skips `caffeinate` entirely while on battery (`skip_on_battery=True` by default, overridable).
- The power source is cached for 30s so this costs at most one subprocess per poll window, not one per tick.
- An unknown power source keeps the machine awake rather than silently disabling itself — failing safe toward the documented behavior, not quiet.
- `detail()` reports `Keep awake paused on battery` so the state is visible instead of looking broken.

## Tests

204 pass. New coverage:

- `keep_awake_enabled` default, file round-trip, and absent-key default
- battery skip / AC hold / release-on-switch-to-battery
- power-source poll caching
- `skip_on_battery=False` escape hatch
- unknown power source still holds
- `pmset -g ps` parsing, including command failure
- `build_keep_awake_controller` honors the persisted setting
- toggle persists, and reverts settings when the save fails
- menu exposes the toggle with correct checkbox state

Two pre-existing tests (`test_keep_awake_holds_working_then_graces_done`, `test_keep_awake_ask_grace_expires_without_refresh_extension`) now pass `on_battery_reader=lambda: False` explicitly. They were silently depending on whether the machine running the suite happened to be plugged in; they test grace logic, so the power source belongs pinned.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
