### PR TITLE
Add closed-lid LED idle setting and a Clear Agents menu action

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,11 @@ battery status. When agent status is selected, `Show Battery on Plug/Unplug`
 can briefly show the battery animation for seven seconds after the power source
 changes.
 
+When sessions are listed, the Agents section also offers
+**Clear Agents & Idle LEDs**. It forgets every tracked session and returns the
+LEDs to Idle in one click, which is the quick way out of a stale Ask or Done
+state. Live agents reappear on their next hook event.
+
 The Devices section also offers **Add Screen Bar**, an optional virtual
 eight-LED device. It appears as a notch-shaped status-bar overlay that covers
 the camera island/notch footprint and adds a straight 5 px LED band along the
@@ -454,6 +459,12 @@ live updates from the local hook event socket. Settings are stored at
 Settings can export the hook decision log as CSV or HTML. This log lives at
 `${XDG_STATE_HOME:-~/.local/state}/sidepulse/agent-monitor/event-status.jsonl`
 and shows the path from provider hook event to interpreted SidePulse status.
+
+The `Closed Lid` menu section has **Idle LEDs When Lid Closed** (also a
+checkbox in Settings under Devices & LEDs, off by default). While it is on and
+the lid is shut, every LED display falls back to the dim Idle animation instead
+of agent or battery status; opening the lid restores the normal display. Devices
+set to `Manual` keep whatever program you wrote to them.
 
 The `Keep Awake With Lid Closed` menu section controls the stronger sleep
 prevention policy:

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -422,6 +422,21 @@ class LiveAgentMonitor:
             self.statuses_by_key[status.agent_id] = status
             self.write_latest_state()
 
+    def clear_statuses(self) -> int:
+        """Forget every tracked agent session and persist the empty state.
+
+        Live agents re-register on their next hook event; this only drops what
+        the monitor is currently holding.
+        """
+        with self.lock:
+            cleared = len(self.statuses_by_key)
+            self.statuses_by_key.clear()
+            self.metadata_by_session.clear()
+            self.metadata_by_status.clear()
+            self.pending_permissions_by_key.clear()
+            self.write_latest_state()
+        return cleared
+
     def snapshot(self, include_stale: bool = False) -> MonitorSnapshot:
         now = datetime.now(timezone.utc)
         with self.lock:

--- a/src/sidepulse/settings.py
+++ b/src/sidepulse/settings.py
@@ -140,6 +140,7 @@ class AgentMonitorSettings:
     sleep_prevention_policy: str = SLEEP_PREVENTION_AGENTS
     virtual_status_device_enabled: bool = False
     closed_lid_system_override_enabled: bool = False
+    lid_closed_led_idle_enabled: bool = False
     lid_closed_animation: LedAnimationSetting = field(
         default_factory=lambda: default_lid_animation(LID_ANIMATION_CLOSED)
     )
@@ -407,6 +408,9 @@ class AgentMonitorSettings:
     def with_closed_lid_system_override(self, enabled: bool) -> "AgentMonitorSettings":
         return replace(self, closed_lid_system_override_enabled=bool(enabled))
 
+    def with_lid_closed_led_idle(self, enabled: bool) -> "AgentMonitorSettings":
+        return replace(self, lid_closed_led_idle_enabled=bool(enabled))
+
     def with_lid_animation(
         self,
         kind: str,
@@ -464,6 +468,7 @@ class AgentMonitorSettings:
             "sleep_prevention_policy": self.sleep_prevention_policy,
             "virtual_status_device_enabled": self.virtual_status_device_enabled,
             "closed_lid_system_override_enabled": self.closed_lid_system_override_enabled,
+            "lid_closed_led_idle_enabled": self.lid_closed_led_idle_enabled,
             "lid_closed_animation": self.lid_closed_animation.to_dict(),
             "lid_open_animation": self.lid_open_animation.to_dict(),
             "transcript_monitoring": {
@@ -570,6 +575,10 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
         ),
         closed_lid_system_override_enabled=_bool_setting(
             data.get("closed_lid_system_override_enabled"),
+            False,
+        ),
+        lid_closed_led_idle_enabled=_bool_setting(
+            data.get("lid_closed_led_idle_enabled"),
             False,
         ),
         lid_closed_animation=_lid_animation_setting(

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -711,6 +711,18 @@ class StatusBarController(NSObject):
         self.set_battery_led_display(sender.state() == NSOnState)
 
     @objc.IBAction
+    def toggleLidClosedLedIdle_(self, _sender):
+        self.set_lid_closed_led_idle(not self.settings.lid_closed_led_idle_enabled)
+
+    @objc.IBAction
+    def setLidClosedLedIdleFromCheckbox_(self, sender):
+        self.set_lid_closed_led_idle(sender.state() == NSOnState)
+
+    @objc.IBAction
+    def clearAgents_(self, _sender):
+        self.clear_agents()
+
+    @objc.IBAction
     def toggleBatteryPowerPreview_(self, _sender):
         self.set_battery_power_preview(not self.settings.battery_show_on_power_change)
 
@@ -1036,6 +1048,10 @@ class StatusBarController(NSObject):
             self.settings_buttons.get("battery_power_preview"),
             self.settings.battery_show_on_power_change,
         )
+        set_checkbox_state(
+            self.settings_buttons.get("lid_closed_led_idle"),
+            self.settings.lid_closed_led_idle_enabled,
+        )
         for provider in ("codex", "claude", "grok"):
             popup = self.settings_fields.get(f"{provider}_session_opener")
             if popup is not None:
@@ -1277,6 +1293,44 @@ class StatusBarController(NSObject):
         self.reset_led_controllers_for_display_change()
         self.set_settings_message(f"LED display set to {self.settings.led_display}.")
         self.refresh_settings_window()
+        self.refresh_(None)
+
+    def set_lid_closed_led_idle(self, enabled: bool) -> None:
+        try:
+            self.settings = self.settings.with_lid_closed_led_idle(enabled)
+            save_settings(self.settings)
+        except Exception as exc:
+            self.set_settings_message(f"Could not save settings: {exc}")
+            self.settings = load_settings()
+            self.refresh_settings_window()
+            return
+
+        self.reset_led_controllers_for_display_change()
+        self.set_settings_message(
+            "LEDs idle while the lid is closed."
+            if self.settings.lid_closed_led_idle_enabled
+            else "LEDs keep their normal display while the lid is closed."
+        )
+        self.refresh_settings_window()
+        self.refresh_(None)
+
+    def clear_agents(self) -> None:
+        try:
+            cleared = self.monitor.clear_statuses()
+        except Exception as exc:
+            log_status_bar(f"clear agents error: {exc}")
+            self.set_settings_message(f"Could not clear agents: {exc}")
+            return
+
+        log_status_bar(f"agents cleared count={cleared}")
+        self.agent_awake_last_mode = None
+        self.agent_awake_grace_until_monotonic = None
+        self.agent_awake_requested = False
+        # Drop any in-flight lid animation so its restore pass cannot repaint
+        # the LEDs after the idle write below.
+        self.led_animation_token += 1
+        self.led_animation_until_monotonic = 0.0
+        self.reset_led_controllers_for_display_change()
         self.refresh_(None)
 
     def set_device_display(self, device_id: str | None, display: str) -> None:
@@ -1665,9 +1719,15 @@ class StatusBarController(NSObject):
 
         self.last_status_history_error = None
 
+    def led_idle_override_active(self) -> bool:
+        """True while the lid-closed setting should force the LEDs to Idle."""
+        return bool(self.settings.lid_closed_led_idle_enabled) and self.last_lid_closed is True
+
     def active_led_display_kind(self, snapshot: BatterySnapshot | None) -> str:
         if self.settings.led_display == LED_DISPLAY_CUSTOM:
             return LED_DISPLAY_CUSTOM
+        if self.led_idle_override_active():
+            return LED_DISPLAY_AGENT
         if self.settings.led_display == LED_DISPLAY_BATTERY:
             return LED_DISPLAY_BATTERY
         if snapshot is not None and time.monotonic() < self.battery_preview_until:
@@ -1830,6 +1890,8 @@ class StatusBarController(NSObject):
     ) -> str:
         if device.display == LED_DISPLAY_CUSTOM:
             return LED_DISPLAY_CUSTOM
+        if self.led_idle_override_active():
+            return LED_DISPLAY_AGENT
         if device.display == LED_DISPLAY_BATTERY:
             return LED_DISPLAY_BATTERY
         if battery_snapshot is not None and time.monotonic() < self.battery_preview_until:
@@ -1845,6 +1907,11 @@ class StatusBarController(NSObject):
         if not self.leds_enabled:
             return
 
+        if self.led_idle_override_active():
+            mode = AgentMode.IDLE_READY
+            battery_snapshot = None
+            display_kind = LED_DISPLAY_AGENT
+
         self.sync_virtual_status_device(mode, battery_snapshot)
 
         if time.monotonic() < self.led_animation_until_monotonic:
@@ -1859,6 +1926,15 @@ class StatusBarController(NSObject):
             daemon=True,
         )
         thread.start()
+
+    def resync_leds_from_last_snapshot(self) -> None:
+        if self.last_snapshot is None:
+            return
+        self.sync_leds(
+            self.last_snapshot.aggregate.mode,
+            self.last_battery_snapshot,
+            self.active_led_display_kind(self.last_battery_snapshot),
+        )
 
     def sync_virtual_status_device(
         self,
@@ -2151,6 +2227,13 @@ class StatusBarController(NSObject):
         kind = LID_ANIMATION_CLOSED if closed else LID_ANIMATION_OPEN
         log_status_bar(f"lid_state={'closed' if closed else 'open'}")
         self.play_lid_animation(kind)
+        if self.settings.lid_closed_led_idle_enabled:
+            log_status_bar(f"lid_led_idle={'active' if closed else 'released'}")
+            # The animation's restore pass resyncs the LEDs when one played;
+            # without it nothing else would apply the override until the next
+            # 15s refresh.
+            if time.monotonic() >= self.led_animation_until_monotonic:
+                self.resync_leds_from_last_snapshot()
 
     @objc.IBAction
     def pollDevices_(self, _sender):
@@ -2302,6 +2385,14 @@ def build_menu(snapshot, state: StatusBarState, target: StatusBarController) -> 
                 )
             )
 
+        clear_agents = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Clear Agents & Idle LEDs",
+            "clearAgents:",
+            "",
+        )
+        clear_agents.setTarget_(target)
+        menu.addItem_(clear_agents)
+
     menu.addItem_(NSMenuItem.separatorItem())
     menu.addItem_(disabled_menu_item("Devices"))
     devices = target.status_bar_devices()
@@ -2318,6 +2409,17 @@ def build_menu(snapshot, state: StatusBarState, target: StatusBarController) -> 
         )
         virtual_toggle.setTarget_(target)
         menu.addItem_(virtual_toggle)
+
+    menu.addItem_(NSMenuItem.separatorItem())
+    menu.addItem_(disabled_menu_item("Closed Lid"))
+    lid_idle = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+        "Idle LEDs When Lid Closed",
+        "toggleLidClosedLedIdle:",
+        "",
+    )
+    lid_idle.setTarget_(target)
+    lid_idle.setState_(1 if target.settings.lid_closed_led_idle_enabled else 0)
+    menu.addItem_(lid_idle)
 
     menu.addItem_(NSMenuItem.separatorItem())
     menu.addItem_(disabled_menu_item("Closed-Lid Sleep Prevention"))
@@ -3317,6 +3419,16 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         target,
         "setBatteryPowerPreviewFromCheckbox:",
     )
+    lid_closed_led_idle = add_checkbox(
+        devices_tab,
+        "Idle LEDs while the lid is closed",
+        32,
+        280,
+        320,
+        24,
+        target,
+        "setLidClosedLedIdleFromCheckbox:",
+    )
 
     add_label(sleep_tab, "Lid Closed", 24, 398, 120, 22)
     add_label(sleep_tab, "Duration", 516, 398, 70, 22)
@@ -3402,6 +3514,7 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         "claude_transcripts": claude_transcripts,
         "battery_leds": battery_leds,
         "battery_power_preview": battery_power_preview,
+        "lid_closed_led_idle": lid_closed_led_idle,
     }
     return window
 

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -606,6 +606,42 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(reloaded.snapshot().aggregate.mode, AgentMode.TOOL_RUNNING)
             self.assertEqual(reloaded.snapshot().statuses[0].origin, "Codex UI")
 
+    def test_live_sidepulse_clear_statuses_empties_state_and_persists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            latest = base / "latest.json"
+            source = SourceSpec("event-bus", base / "events.sock")
+            monitor = LiveAgentMonitor(
+                sources=(source,),
+                stale_after_seconds=3600,
+                latest_state_path=latest,
+            )
+            line = {
+                "logged_at": datetime.now(timezone.utc).isoformat(),
+                "event": {
+                    "hook_event_name": "PreToolUse",
+                    "session_id": "codex-session",
+                    "cwd": "/tmp/project",
+                    "tool_name": "Bash",
+                },
+            }
+            monitor.ingest_record(parse_log_line("codex", json.dumps(line)))
+            self.assertEqual(monitor.snapshot().aggregate.mode, AgentMode.TOOL_RUNNING)
+
+            cleared = monitor.clear_statuses()
+
+            self.assertEqual(cleared, 1)
+            self.assertEqual(monitor.snapshot(include_stale=True).statuses, ())
+            self.assertEqual(monitor.snapshot().aggregate.mode, AgentMode.IDLE_READY)
+            # A cleared session must not come back when the app restarts.
+            reloaded = LiveAgentMonitor(
+                sources=(source,),
+                stale_after_seconds=3600,
+                latest_state_path=latest,
+            )
+            self.assertEqual(reloaded.snapshot().aggregate.mode, AgentMode.IDLE_READY)
+            self.assertEqual(monitor.clear_statuses(), 0)
+
     def test_status_bar_startup_replay_ingests_recent_debug_logs(self) -> None:
         try:
             from sidepulse import status_bar
@@ -4515,6 +4551,13 @@ class AgentMonitorTests(unittest.TestCase):
             loaded_enabled = load_settings(settings_path)
             self.assertTrue(loaded_enabled.closed_lid_system_override_enabled)
 
+            self.assertFalse(settings.lid_closed_led_idle_enabled)
+            lid_idle = settings.with_lid_closed_led_idle(True)
+            save_settings(lid_idle, settings_path)
+            self.assertTrue(load_settings(settings_path).lid_closed_led_idle_enabled)
+            save_settings(lid_idle.with_lid_closed_led_idle(False), settings_path)
+            self.assertFalse(load_settings(settings_path).lid_closed_led_idle_enabled)
+
             completed = settings.with_setup_screen_completed(True)
             save_settings(completed, settings_path)
             loaded_completed = load_settings(settings_path)
@@ -4531,6 +4574,7 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(loaded.sleep_prevention_min_battery_percent, 20)
             self.assertEqual(loaded.history_timeframe_seconds, DEFAULT_HISTORY_TIMEFRAME_SECONDS)
             self.assertFalse(loaded.closed_lid_system_override_enabled)
+            self.assertFalse(loaded.lid_closed_led_idle_enabled)
             self.assertFalse(loaded.setup_screen_completed)
             self.assertEqual(
                 loaded.lid_animation(LID_ANIMATION_CLOSED),

--- a/tests/test_status_bar_ui.py
+++ b/tests/test_status_bar_ui.py
@@ -20,6 +20,8 @@ import ast
 import os
 import re
 import tempfile
+import threading
+import time
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -67,6 +69,7 @@ from sidepulse import status_bar as sb  # noqa: E402
 from sidepulse import virtual_device as vd  # noqa: E402
 from sidepulse.collector import MonitorSnapshot, SourceSpec  # noqa: E402
 from sidepulse.models import AgentMode, AgentStatus, AggregateStatus  # noqa: E402
+from sidepulse.settings import AgentMonitorSettings  # noqa: E402
 
 
 # A selector literal: camelCase identifier ending in a single colon.
@@ -402,6 +405,211 @@ class IconTests(StatusBarTestCase):
                 self.assertIsInstance(
                     sb.image_for_symbol(state.symbol, state.label), NSImage
                 )
+
+
+class ClearAgentsTests(StatusBarTestCase):
+    """The menu's Clear Agents entry drops sessions and returns LEDs to Idle."""
+
+    def setUp(self):
+        patcher = patch.object(sb, "discover_devices", return_value=[])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self.controller.monitor.statuses_by_key.clear)
+
+    def test_clear_agents_item_appears_only_when_sessions_are_listed(self):
+        empty = sb.build_menu(make_snapshot(), sb.STATE_IDLE, self.controller)
+        self.assertNotIn(
+            "Clear Agents & Idle LEDs",
+            [item.title() for item in walk_menu(empty)],
+        )
+
+        populated = sb.build_menu(
+            make_snapshot(statuses=[make_status()]),
+            sb.STATE_WORKING,
+            self.controller,
+        )
+        clear = next(
+            item for item in walk_menu(populated)
+            if item.title() == "Clear Agents & Idle LEDs"
+        )
+        self.assertTrue(clear.target().respondsToSelector_("clearAgents:"))
+
+    def test_clear_agents_empties_the_monitor_and_leaves_an_idle_aggregate(self):
+        class FakeStatusItem:
+            """The real NSStatusItem only exists once the app has launched."""
+
+            def __init__(self):
+                self.menu = None
+
+            def button(self):
+                return None
+
+            def setMenu_(self, menu):
+                self.menu = menu
+
+        status = make_status(mode=AgentMode.WAITING_FOR_INPUT)
+        self.controller.monitor.statuses_by_key[status.agent_id] = status
+        self.controller.status_item = FakeStatusItem()
+        self.addCleanup(setattr, self.controller, "status_item", None)
+        # A lid animation in flight would otherwise repaint the LEDs after the
+        # clear, so the clear has to cancel it.
+        self.controller.led_animation_until_monotonic = time.monotonic() + 600
+
+        self.controller.clear_agents()
+
+        self.assertEqual({}, self.controller.monitor.statuses_by_key)
+        self.assertEqual(
+            AgentMode.IDLE_READY,
+            self.controller.monitor.snapshot().aggregate.mode,
+        )
+        self.assertEqual(0.0, self.controller.led_animation_until_monotonic)
+        self.assertFalse(self.controller.agent_awake_requested)
+        self.assertIsNotNone(self.controller.status_item.menu)
+
+
+class LidClosedLedIdleTests(StatusBarTestCase):
+    """With the setting on, a closed lid pins every LED display to Idle."""
+
+    def setUp(self):
+        original = self.controller.settings
+        original_lid = self.controller.last_lid_closed
+        self.addCleanup(setattr, self.controller, "settings", original)
+        self.addCleanup(setattr, self.controller, "last_lid_closed", original_lid)
+
+    def configure(self, *, enabled: bool, lid_closed, led_display=sb.LED_DISPLAY_AGENT):
+        self.controller.settings = AgentMonitorSettings(
+            lid_closed_led_idle_enabled=enabled,
+            led_display=led_display,
+        )
+        self.controller.last_lid_closed = lid_closed
+
+    def test_override_requires_both_the_setting_and_a_closed_lid(self):
+        cases = {
+            (True, True): True,
+            (True, False): False,
+            (True, None): False,   # lid state not read yet
+            (False, True): False,
+            (False, False): False,
+        }
+        for (enabled, lid_closed), expected in cases.items():
+            with self.subTest(enabled=enabled, lid_closed=lid_closed):
+                self.configure(enabled=enabled, lid_closed=lid_closed)
+                self.assertIs(expected, self.controller.led_idle_override_active())
+
+    def test_closed_lid_pins_a_battery_display_back_to_agent_status(self):
+        self.configure(
+            enabled=True,
+            lid_closed=True,
+            led_display=sb.LED_DISPLAY_BATTERY,
+        )
+        device = make_device()
+        battery_device = sb.StatusBarDevice(
+            device_id=device.device_id,
+            name=device.name,
+            root=device.root,
+            target=device.target,
+            connected=True,
+            display=sb.LED_DISPLAY_BATTERY,
+            brightness=255,
+        )
+
+        self.assertEqual(
+            sb.LED_DISPLAY_AGENT,
+            self.controller.active_led_display_kind(None),
+        )
+        self.assertEqual(
+            sb.LED_DISPLAY_AGENT,
+            self.controller.active_led_display_kind_for_device(battery_device, None),
+        )
+
+        # Open the lid again and the battery display comes straight back.
+        self.controller.last_lid_closed = False
+        self.assertEqual(
+            sb.LED_DISPLAY_BATTERY,
+            self.controller.active_led_display_kind(None),
+        )
+        self.assertEqual(
+            sb.LED_DISPLAY_BATTERY,
+            self.controller.active_led_display_kind_for_device(battery_device, None),
+        )
+
+    def test_manual_devices_keep_their_program_while_the_lid_is_closed(self):
+        """Manual means the user owns the strip; the override must not steal it."""
+        self.configure(enabled=True, lid_closed=True)
+        manual = sb.StatusBarDevice(
+            device_id="manual",
+            name="MANUAL",
+            root=Path("/Volumes/MANUAL"),
+            target=Path("/Volumes/MANUAL/leds.txt"),
+            connected=True,
+            display=sb.LED_DISPLAY_CUSTOM,
+            brightness=255,
+        )
+        self.assertEqual(
+            sb.LED_DISPLAY_CUSTOM,
+            self.controller.active_led_display_kind_for_device(manual, None),
+        )
+
+    def test_sync_leds_forces_idle_while_the_lid_is_closed(self):
+        self.configure(
+            enabled=True,
+            lid_closed=True,
+            led_display=sb.LED_DISPLAY_BATTERY,
+        )
+        seen = []
+        done = threading.Event()
+
+        def capture(mode, battery_snapshot, display_kind):
+            seen.append((mode, battery_snapshot, display_kind))
+            done.set()
+
+        self.controller.sync_leds_now = capture
+        self.addCleanup(lambda: self.controller.__dict__.pop("sync_leds_now", None))
+
+        self.controller.sync_leds(
+            AgentMode.WORKING,
+            object(),  # a battery snapshot the override must discard
+            sb.LED_DISPLAY_BATTERY,
+        )
+
+        self.assertTrue(done.wait(5), "sync_leds never reached the LED writer")
+        self.assertEqual(
+            [(AgentMode.IDLE_READY, None, sb.LED_DISPLAY_AGENT)],
+            seen,
+        )
+
+    def test_sync_leds_passes_the_real_mode_through_when_the_lid_is_open(self):
+        self.configure(enabled=True, lid_closed=False)
+        seen = []
+        done = threading.Event()
+
+        def capture(mode, battery_snapshot, display_kind):
+            seen.append((mode, display_kind))
+            done.set()
+
+        self.controller.sync_leds_now = capture
+        self.addCleanup(lambda: self.controller.__dict__.pop("sync_leds_now", None))
+
+        self.controller.sync_leds(AgentMode.WORKING, None, sb.LED_DISPLAY_AGENT)
+
+        self.assertTrue(done.wait(5), "sync_leds never reached the LED writer")
+        self.assertEqual([(AgentMode.WORKING, sb.LED_DISPLAY_AGENT)], seen)
+
+    def test_lid_idle_menu_item_tracks_the_setting(self):
+        with patch.object(sb, "discover_devices", return_value=[]):
+            for enabled in (True, False):
+                with self.subTest(enabled=enabled):
+                    self.configure(enabled=enabled, lid_closed=None)
+                    menu = sb.build_menu(
+                        make_snapshot(),
+                        sb.STATE_IDLE,
+                        self.controller,
+                    )
+                    item = next(
+                        item for item in walk_menu(menu)
+                        if item.title() == "Idle LEDs When Lid Closed"
+                    )
+                    self.assertEqual(1 if enabled else 0, item.state())
 
 
 class PureUiLogicTests(unittest.TestCase):


### PR DESCRIPTION
Two menu-bar app additions.

**Idle LEDs when the lid is closed**:  new setting `lid_closed_led_idle_enabled`
(default off), in the dropdown under `Closed Lid` and as a checkbox in
Settings → Devices & LEDs. While it's on and the lid is shut, every LED display
falls back to the dim Idle animation instead of agent or battery status;
opening the lid restores the normal display. Devices set to Manual are left
alone. The override hooks the existing 1 Hz clamshell poller and resyncs
immediately on a lid transition rather than waiting for the next 15s refresh.

**Clear Agents & Idle LEDs**:  new item in the Agents section, shown when
sessions are listed. Drops every tracked session via
`LiveAgentMonitor.clear_statuses()`, which also clears the metadata caches and
rewrites `latest.json` so cleared sessions don't return on restart, then idles
the LEDs. It cancels any in-flight lid animation, whose restore pass would
otherwise repaint the strip afterwards. Live agents re-register on their next
hook event.

Existing settings files stay valid:  the new key defaults to off.

Tests: full suite 289 passed / 11 skipped (was 280), plus clean-room install and
packaging. New coverage for the settings round-trip and default migration,
`clear_statuses` including reload-after-clear, the override truth table, the
battery→agent pinning and its restoration on lid open, Manual devices being
untouched, `sync_leds` forcing Idle vs. passing the real mode through, and both
menu items' wiring and check state.


**Menu bar**:
<img width="304" height="295" alt="SCR-20260822-qkce" src="https://github.com/user-attachments/assets/d884c7bb-c0d0-4289-b8b1-066b8184bf96" />

**macOS App**:
<img width="428" height="275" alt="SCR-20260822-qkgw" src="https://github.com/user-attachments/assets/7f57dcd0-b376-4de9-a823-d324d9f63a81" />



 
