### PR TITLE
Add manual and scheduled Do Not Disturb mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,10 +422,11 @@ The status-bar item shows one of four collapsed states:
 
 Do Not Disturb keeps all physical SidePulse LEDs and the optional Screen Bar off while
 agent monitoring continues normally. Toggle it immediately from the menu-bar dropdown,
-or open **Settings... → Devices & LEDs** to enable manual DND or a recurring daily
-schedule such as `22:00`–`07:00`. Overnight schedules that cross midnight are supported.
-Changes take effect immediately, and normal LED status resumes automatically when DND
-ends.
+or open **Settings... → Devices & LEDs** to use the same DND toggle and optionally set a
+recurring daily schedule such as `21:00`–`07:00`. The schedule switches the toggle on at
+the start time and off at the end time. You can override the toggle at any time; that
+choice remains in effect until the next scheduled boundary, including across app
+restarts. Overnight schedules that cross midnight are supported.
 
 Click the status-bar item to expand the recent session list. Click a session
 row to open that agent using the remembered choice for that provider. Use the

--- a/README.md
+++ b/README.md
@@ -418,6 +418,15 @@ The status-bar item shows one of four collapsed states:
 | Done | The most recent active agent completed successfully. |
 | Ask | An agent needs input, permission, or attention. |
 
+### Do Not Disturb
+
+Do Not Disturb keeps all physical SidePulse LEDs and the optional Screen Bar off while
+agent monitoring continues normally. Toggle it immediately from the menu-bar dropdown,
+or open **Settings... → Devices & LEDs** to enable manual DND or a recurring daily
+schedule such as `22:00`–`07:00`. Overnight schedules that cross midnight are supported.
+Changes take effect immediately, and normal LED status resumes automatically when DND
+ends.
+
 Click the status-bar item to expand the recent session list. Click a session
 row to open that agent using the remembered choice for that provider. Use the
 session's Open Options row to choose and remember another opener, such as the

--- a/src/sidepulse/settings.py
+++ b/src/sidepulse/settings.py
@@ -159,10 +159,11 @@ class AgentMonitorSettings:
     idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS
     sleep_prevention_min_battery_percent: float = DEFAULT_SLEEP_PREVENTION_MIN_BATTERY_PERCENT
     history_timeframe_seconds: float = DEFAULT_HISTORY_TIMEFRAME_SECONDS
-    dnd_manual_enabled: bool = False
+    dnd_enabled: bool = False
     dnd_schedule_enabled: bool = False
     dnd_start_time: str = DEFAULT_DND_START_TIME
     dnd_end_time: str = DEFAULT_DND_END_TIME
+    dnd_last_schedule_transition: str = ""
     setup_screen_completed: bool = False
 
     def transcript_enabled(self, provider: str) -> bool:
@@ -466,17 +467,18 @@ class AgentMonitorSettings:
     def with_dnd(
         self,
         *,
-        manual_enabled: bool | None = None,
+        enabled: bool | None = None,
         schedule_enabled: bool | None = None,
         start_time: str | None = None,
         end_time: str | None = None,
+        schedule_transition: str | None = None,
     ) -> "AgentMonitorSettings":
         return replace(
             self,
-            dnd_manual_enabled=(
-                self.dnd_manual_enabled
-                if manual_enabled is None
-                else bool(manual_enabled)
+            dnd_enabled=(
+                self.dnd_enabled
+                if enabled is None
+                else bool(enabled)
             ),
             dnd_schedule_enabled=(
                 self.dnd_schedule_enabled
@@ -492,6 +494,11 @@ class AgentMonitorSettings:
                 self.dnd_end_time
                 if end_time is None
                 else normalize_dnd_time(end_time)
+            ),
+            dnd_last_schedule_transition=(
+                self.dnd_last_schedule_transition
+                if schedule_transition is None
+                else str(schedule_transition)
             ),
         )
 
@@ -530,10 +537,11 @@ class AgentMonitorSettings:
                 "timeframe_seconds": self.history_timeframe_seconds,
             },
             "do_not_disturb": {
-                "manual_enabled": self.dnd_manual_enabled,
+                "enabled": self.dnd_enabled,
                 "schedule_enabled": self.dnd_schedule_enabled,
                 "start_time": self.dnd_start_time,
                 "end_time": self.dnd_end_time,
+                "last_schedule_transition": self.dnd_last_schedule_transition,
             },
             "setup_screen_completed": self.setup_screen_completed,
         }
@@ -668,7 +676,10 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
                 data.get("history_timeframe_seconds", DEFAULT_HISTORY_TIMEFRAME_SECONDS),
             )
         ),
-        dnd_manual_enabled=_bool_setting(dnd.get("manual_enabled"), False),
+        dnd_enabled=_bool_setting(
+            dnd.get("enabled"),
+            _bool_setting(dnd.get("manual_enabled"), False),
+        ),
         dnd_schedule_enabled=_bool_setting(dnd.get("schedule_enabled"), False),
         dnd_start_time=_dnd_time_setting(
             dnd.get("start_time"),
@@ -677,6 +688,9 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
         dnd_end_time=_dnd_time_setting(
             dnd.get("end_time"),
             DEFAULT_DND_END_TIME,
+        ),
+        dnd_last_schedule_transition=_string_setting(
+            dnd.get("last_schedule_transition")
         ),
         setup_screen_completed=_bool_setting(data.get("setup_screen_completed"), False),
     )

--- a/src/sidepulse/settings.py
+++ b/src/sidepulse/settings.py
@@ -99,6 +99,8 @@ HISTORY_TIMEFRAME_CHOICES = (
     HISTORY_TIMEFRAME_24H_SECONDS,
     HISTORY_TIMEFRAME_48H_SECONDS,
 )
+DEFAULT_DND_START_TIME = "22:00"
+DEFAULT_DND_END_TIME = "07:00"
 
 
 @dataclass(frozen=True)
@@ -157,6 +159,10 @@ class AgentMonitorSettings:
     idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS
     sleep_prevention_min_battery_percent: float = DEFAULT_SLEEP_PREVENTION_MIN_BATTERY_PERCENT
     history_timeframe_seconds: float = DEFAULT_HISTORY_TIMEFRAME_SECONDS
+    dnd_manual_enabled: bool = False
+    dnd_schedule_enabled: bool = False
+    dnd_start_time: str = DEFAULT_DND_START_TIME
+    dnd_end_time: str = DEFAULT_DND_END_TIME
     setup_screen_completed: bool = False
 
     def transcript_enabled(self, provider: str) -> bool:
@@ -457,6 +463,38 @@ class AgentMonitorSettings:
     def with_history_timeframe(self, seconds: float) -> "AgentMonitorSettings":
         return replace(self, history_timeframe_seconds=normalize_history_timeframe(seconds))
 
+    def with_dnd(
+        self,
+        *,
+        manual_enabled: bool | None = None,
+        schedule_enabled: bool | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+    ) -> "AgentMonitorSettings":
+        return replace(
+            self,
+            dnd_manual_enabled=(
+                self.dnd_manual_enabled
+                if manual_enabled is None
+                else bool(manual_enabled)
+            ),
+            dnd_schedule_enabled=(
+                self.dnd_schedule_enabled
+                if schedule_enabled is None
+                else bool(schedule_enabled)
+            ),
+            dnd_start_time=(
+                self.dnd_start_time
+                if start_time is None
+                else normalize_dnd_time(start_time)
+            ),
+            dnd_end_time=(
+                self.dnd_end_time
+                if end_time is None
+                else normalize_dnd_time(end_time)
+            ),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "led_display": self.led_display,
@@ -490,6 +528,12 @@ class AgentMonitorSettings:
             },
             "history": {
                 "timeframe_seconds": self.history_timeframe_seconds,
+            },
+            "do_not_disturb": {
+                "manual_enabled": self.dnd_manual_enabled,
+                "schedule_enabled": self.dnd_schedule_enabled,
+                "start_time": self.dnd_start_time,
+                "end_time": self.dnd_end_time,
             },
             "setup_screen_completed": self.setup_screen_completed,
         }
@@ -545,6 +589,9 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
     history = data.get("history")
     if not isinstance(history, dict):
         history = {}
+    dnd = data.get("do_not_disturb")
+    if not isinstance(dnd, dict):
+        dnd = {}
 
     led_display = _led_display_setting(data.get("led_display"), LED_DISPLAY_AGENT)
     session_open_preferences = _session_open_preferences(
@@ -620,6 +667,16 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
                 "timeframe_seconds",
                 data.get("history_timeframe_seconds", DEFAULT_HISTORY_TIMEFRAME_SECONDS),
             )
+        ),
+        dnd_manual_enabled=_bool_setting(dnd.get("manual_enabled"), False),
+        dnd_schedule_enabled=_bool_setting(dnd.get("schedule_enabled"), False),
+        dnd_start_time=_dnd_time_setting(
+            dnd.get("start_time"),
+            DEFAULT_DND_START_TIME,
+        ),
+        dnd_end_time=_dnd_time_setting(
+            dnd.get("end_time"),
+            DEFAULT_DND_END_TIME,
         ),
         setup_screen_completed=_bool_setting(data.get("setup_screen_completed"), False),
     )
@@ -768,6 +825,27 @@ def _nonnegative_float_setting(value: object, default: float) -> float:
     if isinstance(value, (int, float)):
         return normalize_seconds_setting(value)
     return default
+
+
+def normalize_dnd_time(value: str) -> str:
+    text = str(value).strip()
+    match = re.fullmatch(r"(\d{1,2}):(\d{2})", text)
+    if match is None:
+        raise ValueError("DND times must use 24-hour HH:MM format.")
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    if hour > 23 or minute > 59:
+        raise ValueError("DND times must use 24-hour HH:MM format.")
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _dnd_time_setting(value: object, default: str) -> str:
+    if not isinstance(value, str):
+        return default
+    try:
+        return normalize_dnd_time(value)
+    except ValueError:
+        return default
 
 
 def normalize_seconds_setting(value: object) -> float:

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -6,7 +6,7 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 try:
@@ -204,43 +204,75 @@ class StatusBarDevice:
     reason: str = ""
 
 
+@dataclass(frozen=True)
+class DndScheduleTransition:
+    key: str
+    enabled: bool
+
+
 def dnd_is_active(
     settings: AgentMonitorSettings,
     now: datetime | None = None,
 ) -> bool:
-    if settings.dnd_manual_enabled:
-        return True
+    return settings.dnd_enabled
+
+
+def latest_dnd_schedule_transition(
+    settings: AgentMonitorSettings,
+    now: datetime | None = None,
+) -> DndScheduleTransition | None:
     if not settings.dnd_schedule_enabled:
-        return False
+        return None
 
     current = now or datetime.now().astimezone()
-    current_minutes = current.hour * 60 + current.minute
-    start_minutes = dnd_time_minutes(settings.dnd_start_time)
-    end_minutes = dnd_time_minutes(settings.dnd_end_time)
-    if start_minutes == end_minutes:
-        return True
-    if start_minutes < end_minutes:
-        return start_minutes <= current_minutes < end_minutes
-    return current_minutes >= start_minutes or current_minutes < end_minutes
+    start_parts = tuple(int(part) for part in settings.dnd_start_time.split(":", 1))
+    end_parts = tuple(int(part) for part in settings.dnd_end_time.split(":", 1))
+    boundaries = [("start", start_parts, True)]
+    if start_parts != end_parts:
+        boundaries.append(("end", end_parts, False))
+
+    due: list[tuple[datetime, str, bool]] = []
+    for day_offset in (-1, 0):
+        day = current + timedelta(days=day_offset)
+        for label, (hour, minute), enabled in boundaries:
+            boundary = day.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            if boundary <= current:
+                due.append((boundary, label, enabled))
+
+    boundary, label, enabled = max(due, key=lambda item: item[0])
+    key = f"{boundary:%Y-%m-%d}:{label}:{boundary:%H:%M}"
+    return DndScheduleTransition(key=key, enabled=enabled)
 
 
-def dnd_time_minutes(value: str) -> int:
-    hour, minute = (int(part) for part in value.split(":", 1))
-    return hour * 60 + minute
+def settings_after_dnd_schedule_transition(
+    settings: AgentMonitorSettings,
+    now: datetime | None = None,
+    *,
+    force: bool = False,
+) -> AgentMonitorSettings:
+    transition = latest_dnd_schedule_transition(settings, now)
+    if transition is None:
+        return settings
+    if not force and transition.key == settings.dnd_last_schedule_transition:
+        return settings
+    return settings.with_dnd(
+        enabled=transition.enabled,
+        schedule_transition=transition.key,
+    )
 
 
 def dnd_status_text(
     settings: AgentMonitorSettings,
     now: datetime | None = None,
 ) -> str:
-    if settings.dnd_manual_enabled:
-        return "DND is active manually. LEDs are off."
+    if settings.dnd_enabled:
+        status = "DND is on. LEDs are off."
+    else:
+        status = "DND is off."
     if settings.dnd_schedule_enabled:
         schedule = f"{settings.dnd_start_time}–{settings.dnd_end_time}"
-        if dnd_is_active(settings, now):
-            return f"Scheduled DND is active ({schedule}). LEDs are off."
-        return f"DND is off. Scheduled for {schedule}."
-    return "DND is off."
+        return f"{status} Schedule: {schedule}."
+    return status
 
 
 @dataclass(frozen=True)
@@ -512,6 +544,7 @@ class StatusBarController(NSObject):
 
     @objc.IBAction
     def refresh_(self, _sender):
+        self.apply_due_dnd_schedule()
         try:
             snapshot = self.monitor.snapshot(include_stale=False)
         except Exception as exc:
@@ -766,11 +799,11 @@ class StatusBarController(NSObject):
 
     @objc.IBAction
     def toggleDnd_(self, _sender):
-        self.set_dnd_manual(not self.settings.dnd_manual_enabled)
+        self.set_dnd_enabled(not self.settings.dnd_enabled)
 
     @objc.IBAction
-    def setDndManualFromCheckbox_(self, sender):
-        self.set_dnd_manual(sender.state() == NSOnState)
+    def setDndFromCheckbox_(self, sender):
+        self.set_dnd_enabled(sender.state() == NSOnState)
 
     @objc.IBAction
     def saveDndSettings_(self, _sender):
@@ -1095,8 +1128,8 @@ class StatusBarController(NSObject):
             self.settings.battery_show_on_power_change,
         )
         set_checkbox_state(
-            self.settings_buttons.get("dnd_manual"),
-            self.settings.dnd_manual_enabled,
+            self.settings_buttons.get("dnd_enabled"),
+            self.settings.dnd_enabled,
         )
         set_checkbox_state(
             self.settings_buttons.get("dnd_schedule"),
@@ -1667,9 +1700,9 @@ class StatusBarController(NSObject):
         self.refresh_settings_window()
         self.refresh_(None)
 
-    def set_dnd_manual(self, enabled: bool) -> None:
+    def set_dnd_enabled(self, enabled: bool) -> None:
         try:
-            self.settings = self.settings.with_dnd(manual_enabled=enabled)
+            self.settings = self.settings.with_dnd(enabled=enabled)
             save_settings(self.settings)
         except Exception as exc:
             self.set_settings_message(f"Could not save DND setting: {exc}")
@@ -1697,7 +1730,13 @@ class StatusBarController(NSObject):
                 schedule_enabled=schedule_enabled,
                 start_time=start_time,
                 end_time=end_time,
+                schedule_transition="",
             )
+            if schedule_enabled:
+                self.settings = settings_after_dnd_schedule_transition(
+                    self.settings,
+                    force=True,
+                )
             save_settings(self.settings)
         except Exception as exc:
             self.set_settings_message(f"Could not save DND schedule: {exc}")
@@ -1712,6 +1751,25 @@ class StatusBarController(NSObject):
         )
         self.refresh_settings_window()
         self.refresh_(None)
+
+    def apply_due_dnd_schedule(self, now: datetime | None = None) -> bool:
+        updated = settings_after_dnd_schedule_transition(self.settings, now)
+        if updated == self.settings:
+            return False
+
+        previous_enabled = self.settings.dnd_enabled
+        self.settings = updated
+        try:
+            save_settings(self.settings)
+        except Exception as exc:
+            log_status_bar(f"dnd schedule save error: {exc}")
+        self.prepare_for_dnd_change()
+        self.refresh_settings_window()
+        if previous_enabled != self.settings.dnd_enabled:
+            log_status_bar(
+                f"dnd schedule switched {'on' if self.settings.dnd_enabled else 'off'}"
+            )
+        return True
 
     def prepare_for_dnd_change(self) -> None:
         self.last_dnd_active = None
@@ -2509,19 +2567,18 @@ def build_menu(snapshot, state: StatusBarState, target: StatusBarController) -> 
 
     menu.addItem_(NSMenuItem.separatorItem())
     menu.addItem_(disabled_menu_item("Do Not Disturb"))
-    dnd_manual = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-        "Turn DND On Manually",
+    dnd_enabled = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+        "DND On",
         "toggleDnd:",
         "",
     )
-    dnd_manual.setTarget_(target)
-    dnd_manual.setState_(1 if target.settings.dnd_manual_enabled else 0)
-    menu.addItem_(dnd_manual)
+    dnd_enabled.setTarget_(target)
+    dnd_enabled.setState_(1 if target.settings.dnd_enabled else 0)
+    menu.addItem_(dnd_enabled)
     if target.settings.dnd_schedule_enabled:
-        active_label = "Active" if dnd_is_active(target.settings) else "Scheduled"
         menu.addItem_(
             disabled_menu_item(
-                f"{active_label}: {target.settings.dnd_start_time}–{target.settings.dnd_end_time}"
+                f"Schedule: {target.settings.dnd_start_time}–{target.settings.dnd_end_time}"
             )
         )
 
@@ -3525,15 +3582,15 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
     )
     add_separator(devices_tab, 24, 282, tab_width - 48)
     add_label(devices_tab, "Do Not Disturb", 24, 248, 240, 24)
-    dnd_manual = add_checkbox(
+    dnd_enabled = add_checkbox(
         devices_tab,
-        "Turn DND on manually",
+        "DND On",
         32,
         210,
         240,
         24,
         target,
-        "setDndManualFromCheckbox:",
+        "setDndFromCheckbox:",
     )
     dnd_schedule = add_checkbox(
         devices_tab,
@@ -3563,7 +3620,7 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
     dnd_status = add_label(devices_tab, "", 32, 94, 590, 22)
     add_label(
         devices_tab,
-        "Monitoring continues during DND; all physical and on-screen LEDs stay off.",
+        "The schedule switches this toggle on/off; you can override it at any time.",
         32,
         62,
         590,
@@ -3657,7 +3714,7 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         "claude_transcripts": claude_transcripts,
         "battery_leds": battery_leds,
         "battery_power_preview": battery_power_preview,
-        "dnd_manual": dnd_manual,
+        "dnd_enabled": dnd_enabled,
         "dnd_schedule": dnd_schedule,
     }
     return window

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -173,6 +173,7 @@ from .settings import (
     TERMINAL_APP_CHOICES,
     TERMINAL_APP_WARP,
     TERMINAL_APP_WEZTERM,
+    AgentMonitorSettings,
     LedAnimationSetting,
     default_settings_path,
     default_lid_animation,
@@ -201,6 +202,45 @@ class StatusBarDevice:
     display: str
     brightness: int = 255
     reason: str = ""
+
+
+def dnd_is_active(
+    settings: AgentMonitorSettings,
+    now: datetime | None = None,
+) -> bool:
+    if settings.dnd_manual_enabled:
+        return True
+    if not settings.dnd_schedule_enabled:
+        return False
+
+    current = now or datetime.now().astimezone()
+    current_minutes = current.hour * 60 + current.minute
+    start_minutes = dnd_time_minutes(settings.dnd_start_time)
+    end_minutes = dnd_time_minutes(settings.dnd_end_time)
+    if start_minutes == end_minutes:
+        return True
+    if start_minutes < end_minutes:
+        return start_minutes <= current_minutes < end_minutes
+    return current_minutes >= start_minutes or current_minutes < end_minutes
+
+
+def dnd_time_minutes(value: str) -> int:
+    hour, minute = (int(part) for part in value.split(":", 1))
+    return hour * 60 + minute
+
+
+def dnd_status_text(
+    settings: AgentMonitorSettings,
+    now: datetime | None = None,
+) -> str:
+    if settings.dnd_manual_enabled:
+        return "DND is active manually. LEDs are off."
+    if settings.dnd_schedule_enabled:
+        schedule = f"{settings.dnd_start_time}–{settings.dnd_end_time}"
+        if dnd_is_active(settings, now):
+            return f"Scheduled DND is active ({schedule}). LEDs are off."
+        return f"DND is off. Scheduled for {schedule}."
+    return "DND is off."
 
 
 @dataclass(frozen=True)
@@ -395,6 +435,8 @@ class StatusBarController(NSObject):
         self.device_errors = {}
         self.leds_enabled = True
         self.led_sync_in_flight = False
+        self.last_dnd_active = None
+        self.dnd_off_targets = set()
         self.last_led_error = None
         self.last_led_display_kind = LED_DISPLAY_AGENT
         self.last_connected_device_signature = None
@@ -459,7 +501,11 @@ class StatusBarController(NSObject):
             True,
         )
         self.show_setup_window_if_needed()
-        if SCREEN_BAR_FEATURE_ENABLED and self.settings.virtual_status_device_enabled:
+        if (
+            SCREEN_BAR_FEATURE_ENABLED
+            and self.settings.virtual_status_device_enabled
+            and not dnd_is_active(self.settings)
+        ):
             self.virtual_status_device.show()
         else:
             self.virtual_status_device.hide()
@@ -717,6 +763,18 @@ class StatusBarController(NSObject):
     @objc.IBAction
     def setBatteryPowerPreviewFromCheckbox_(self, sender):
         self.set_battery_power_preview(sender.state() == NSOnState)
+
+    @objc.IBAction
+    def toggleDnd_(self, _sender):
+        self.set_dnd_manual(not self.settings.dnd_manual_enabled)
+
+    @objc.IBAction
+    def setDndManualFromCheckbox_(self, sender):
+        self.set_dnd_manual(sender.state() == NSOnState)
+
+    @objc.IBAction
+    def saveDndSettings_(self, _sender):
+        self.save_dnd_schedule_from_fields()
 
     @objc.IBAction
     def saveAgentListTiming_(self, _sender):
@@ -1035,6 +1093,26 @@ class StatusBarController(NSObject):
         set_checkbox_state(
             self.settings_buttons.get("battery_power_preview"),
             self.settings.battery_show_on_power_change,
+        )
+        set_checkbox_state(
+            self.settings_buttons.get("dnd_manual"),
+            self.settings.dnd_manual_enabled,
+        )
+        set_checkbox_state(
+            self.settings_buttons.get("dnd_schedule"),
+            self.settings.dnd_schedule_enabled,
+        )
+        set_text_control_value(
+            self.settings_fields.get("dnd_start_time"),
+            self.settings.dnd_start_time,
+        )
+        set_text_control_value(
+            self.settings_fields.get("dnd_end_time"),
+            self.settings.dnd_end_time,
+        )
+        set_field_value(
+            self.settings_fields.get("dnd_status"),
+            dnd_status_text(self.settings),
         )
         for provider in ("codex", "claude", "grok"):
             popup = self.settings_fields.get(f"{provider}_session_opener")
@@ -1400,7 +1478,7 @@ class StatusBarController(NSObject):
         except Exception as exc:
             self.set_settings_message(f"Could not save Screen Bar: {exc}")
             return
-        if enabled:
+        if enabled and not dnd_is_active(self.settings):
             self.virtual_status_device.show()
         else:
             self.virtual_status_device.hide()
@@ -1588,6 +1666,59 @@ class StatusBarController(NSObject):
         )
         self.refresh_settings_window()
         self.refresh_(None)
+
+    def set_dnd_manual(self, enabled: bool) -> None:
+        try:
+            self.settings = self.settings.with_dnd(manual_enabled=enabled)
+            save_settings(self.settings)
+        except Exception as exc:
+            self.set_settings_message(f"Could not save DND setting: {exc}")
+            self.settings = load_settings()
+            self.refresh_settings_window()
+            return
+
+        self.prepare_for_dnd_change()
+        self.set_settings_message(dnd_status_text(self.settings))
+        self.refresh_settings_window()
+        self.refresh_(None)
+
+    def save_dnd_schedule_from_fields(self) -> None:
+        start_time = text_control_value(
+            self.settings_fields.get("dnd_start_time")
+        ).strip()
+        end_time = text_control_value(
+            self.settings_fields.get("dnd_end_time")
+        ).strip()
+        schedule_enabled = checkbox_is_on(
+            self.settings_buttons.get("dnd_schedule")
+        )
+        try:
+            self.settings = self.settings.with_dnd(
+                schedule_enabled=schedule_enabled,
+                start_time=start_time,
+                end_time=end_time,
+            )
+            save_settings(self.settings)
+        except Exception as exc:
+            self.set_settings_message(f"Could not save DND schedule: {exc}")
+            self.settings = load_settings()
+            self.refresh_settings_window()
+            return
+
+        self.prepare_for_dnd_change()
+        self.set_settings_message(
+            f"DND schedule {'enabled' if schedule_enabled else 'disabled'}: "
+            f"{self.settings.dnd_start_time}–{self.settings.dnd_end_time}."
+        )
+        self.refresh_settings_window()
+        self.refresh_(None)
+
+    def prepare_for_dnd_change(self) -> None:
+        self.last_dnd_active = None
+        self.dnd_off_targets.clear()
+        self.led_animation_token += 1
+        self.led_animation_until_monotonic = 0.0
+        self.reset_led_controllers_for_display_change()
 
     def read_battery_snapshot(self) -> BatterySnapshot | None:
         try:
@@ -1845,6 +1976,18 @@ class StatusBarController(NSObject):
         if not self.leds_enabled:
             return
 
+        dnd_active = dnd_is_active(self.settings)
+        if dnd_active != self.last_dnd_active:
+            self.last_dnd_active = dnd_active
+            self.dnd_off_targets.clear()
+            self.reset_led_controllers_for_display_change()
+            log_status_bar(f"dnd={'active' if dnd_active else 'inactive'}")
+
+        if dnd_active:
+            self.virtual_status_device.hide()
+            self.sync_dnd_leds()
+            return
+
         self.sync_virtual_status_device(mode, battery_snapshot)
 
         if time.monotonic() < self.led_animation_until_monotonic:
@@ -1859,6 +2002,46 @@ class StatusBarController(NSObject):
             daemon=True,
         )
         thread.start()
+
+    def sync_dnd_leds(self) -> None:
+        if self.led_sync_in_flight:
+            return
+        self.led_sync_in_flight = True
+        thread = threading.Thread(
+            target=self.sync_dnd_leds_worker,
+            daemon=True,
+        )
+        thread.start()
+
+    def sync_dnd_leds_worker(self) -> None:
+        try:
+            self.sync_dnd_leds_now()
+        finally:
+            self.led_sync_in_flight = False
+
+    def sync_dnd_leds_now(self) -> None:
+        devices = [
+            device
+            for device in self.status_bar_devices()
+            if device.connected and device.device_id != VIRTUAL_DEVICE_ID
+        ]
+        active_errors: dict[str, str] = {}
+        for device in devices:
+            key = str(device.target)
+            if key in self.dnd_off_targets:
+                continue
+            try:
+                write_led_program("off", device_path=device.target)
+            except Exception as exc:
+                active_errors[device.device_id] = str(exc)
+                log_status_bar(f"dnd off error {device.name}: {exc}")
+                continue
+            self.dnd_off_targets.add(key)
+            self.device_errors.pop(device.device_id, None)
+            log_status_bar(f"dnd off device={device.name} target={device.target}")
+
+        self.device_errors.update(active_errors)
+        self.last_led_error = next(iter(self.device_errors.values()), None)
 
     def sync_virtual_status_device(
         self,
@@ -1917,6 +2100,9 @@ class StatusBarController(NSObject):
         battery_snapshot: BatterySnapshot | None,
         display_kind: str,
     ) -> None:
+        if dnd_is_active(self.settings):
+            self.sync_dnd_leds_now()
+            return
         devices = [
             device for device in self.status_bar_devices()
             if device.connected and device.device_id != VIRTUAL_DEVICE_ID
@@ -1977,7 +2163,7 @@ class StatusBarController(NSObject):
         *,
         animation: LedAnimationSetting | None = None,
     ) -> None:
-        if not self.leds_enabled:
+        if not self.leds_enabled or dnd_is_active(self.settings):
             return
         animation = animation or self.settings.lid_animation(kind)
         try:
@@ -2037,6 +2223,7 @@ class StatusBarController(NSObject):
 
     def connect_device(self) -> None:
         self.leds_enabled = True
+        self.dnd_off_targets.clear()
         self.status_bar_devices()
         self.reset_led_controllers_for_display_change()
         self.last_led_error = None
@@ -2045,6 +2232,7 @@ class StatusBarController(NSObject):
 
     def disconnect_device(self) -> None:
         self.leds_enabled = False
+        self.dnd_off_targets.clear()
         targets = self.current_led_targets()
         if not targets:
             targets = [
@@ -2318,6 +2506,24 @@ def build_menu(snapshot, state: StatusBarState, target: StatusBarController) -> 
         )
         virtual_toggle.setTarget_(target)
         menu.addItem_(virtual_toggle)
+
+    menu.addItem_(NSMenuItem.separatorItem())
+    menu.addItem_(disabled_menu_item("Do Not Disturb"))
+    dnd_manual = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+        "Turn DND On Manually",
+        "toggleDnd:",
+        "",
+    )
+    dnd_manual.setTarget_(target)
+    dnd_manual.setState_(1 if target.settings.dnd_manual_enabled else 0)
+    menu.addItem_(dnd_manual)
+    if target.settings.dnd_schedule_enabled:
+        active_label = "Active" if dnd_is_active(target.settings) else "Scheduled"
+        menu.addItem_(
+            disabled_menu_item(
+                f"{active_label}: {target.settings.dnd_start_time}–{target.settings.dnd_end_time}"
+            )
+        )
 
     menu.addItem_(NSMenuItem.separatorItem())
     menu.addItem_(disabled_menu_item("Closed-Lid Sleep Prevention"))
@@ -3317,6 +3523,52 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         target,
         "setBatteryPowerPreviewFromCheckbox:",
     )
+    add_separator(devices_tab, 24, 282, tab_width - 48)
+    add_label(devices_tab, "Do Not Disturb", 24, 248, 240, 24)
+    dnd_manual = add_checkbox(
+        devices_tab,
+        "Turn DND on manually",
+        32,
+        210,
+        240,
+        24,
+        target,
+        "setDndManualFromCheckbox:",
+    )
+    dnd_schedule = add_checkbox(
+        devices_tab,
+        "Use a daily schedule",
+        32,
+        174,
+        220,
+        24,
+        target,
+        "saveDndSettings:",
+    )
+    add_label(devices_tab, "From", 280, 176, 44, 22)
+    dnd_start_time = add_editable_field(devices_tab, "", 328, 174, 70, 24)
+    add_label(devices_tab, "until", 410, 176, 44, 22)
+    dnd_end_time = add_editable_field(devices_tab, "", 458, 174, 70, 24)
+    add_label(devices_tab, "24-hour time", 540, 176, 90, 22)
+    add_button(
+        devices_tab,
+        "Save Schedule",
+        328,
+        132,
+        124,
+        28,
+        target,
+        "saveDndSettings:",
+    )
+    dnd_status = add_label(devices_tab, "", 32, 94, 590, 22)
+    add_label(
+        devices_tab,
+        "Monitoring continues during DND; all physical and on-screen LEDs stay off.",
+        32,
+        62,
+        590,
+        22,
+    )
 
     add_label(sleep_tab, "Lid Closed", 24, 398, 120, 22)
     add_label(sleep_tab, "Duration", 516, 398, 70, 22)
@@ -3394,6 +3646,9 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         "status_history_timeframe": history_timeframe,
         "status_history_status": history_status,
         "status_history_chart": history_chart,
+        "dnd_start_time": dnd_start_time,
+        "dnd_end_time": dnd_end_time,
+        "dnd_status": dnd_status,
         "message": message,
         "settings_path": settings_path,
     }
@@ -3402,6 +3657,8 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         "claude_transcripts": claude_transcripts,
         "battery_leds": battery_leds,
         "battery_power_preview": battery_power_preview,
+        "dnd_manual": dnd_manual,
+        "dnd_schedule": dnd_schedule,
     }
     return window
 

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -1684,33 +1684,67 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertNotIn("Sleep Helper Missing", titles)
         self.assertIn("Setup...", titles)
 
-    def test_dnd_schedule_handles_overnight_and_daytime_ranges(self) -> None:
+    def test_dnd_schedule_switches_the_toggle_at_overnight_boundaries(self) -> None:
         try:
             from sidepulse import status_bar
         except SystemExit as exc:
             self.skipTest(str(exc))
 
-        overnight = AgentMonitorSettings().with_dnd(
+        settings = AgentMonitorSettings().with_dnd(
             schedule_enabled=True,
-            start_time="22:00",
+            start_time="21:00",
             end_time="07:00",
         )
-        self.assertTrue(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 23, 0)))
-        self.assertTrue(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 6, 59)))
-        self.assertFalse(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 7, 0)))
-        self.assertFalse(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 12, 0)))
+        before_start = status_bar.settings_after_dnd_schedule_transition(
+            settings,
+            datetime(2026, 8, 17, 20, 59),
+            force=True,
+        )
+        self.assertFalse(before_start.dnd_enabled)
 
-        daytime = overnight.with_dnd(start_time="09:00", end_time="17:00")
-        self.assertTrue(status_bar.dnd_is_active(daytime, datetime(2026, 8, 17, 12, 0)))
-        self.assertFalse(status_bar.dnd_is_active(daytime, datetime(2026, 8, 17, 18, 0)))
+        after_start = status_bar.settings_after_dnd_schedule_transition(
+            before_start,
+            datetime(2026, 8, 17, 21, 0),
+        )
+        self.assertTrue(after_start.dnd_enabled)
 
-    def test_manual_dnd_overrides_schedule(self) -> None:
+        manual_override = after_start.with_dnd(enabled=False)
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_path = Path(tmp) / "settings.json"
+            save_settings(manual_override, settings_path)
+            restarted = load_settings(settings_path)
+            before_end = status_bar.settings_after_dnd_schedule_transition(
+                restarted,
+                datetime(2026, 8, 18, 6, 59),
+            )
+        self.assertEqual(before_end, manual_override)
+        self.assertFalse(status_bar.dnd_is_active(before_end))
+
+        after_end = status_bar.settings_after_dnd_schedule_transition(
+            before_end,
+            datetime(2026, 8, 18, 7, 0),
+        )
+        self.assertFalse(after_end.dnd_enabled)
+        self.assertNotEqual(
+            after_end.dnd_last_schedule_transition,
+            before_end.dnd_last_schedule_transition,
+        )
+
+    def test_dnd_toggle_can_override_schedule_in_either_direction(self) -> None:
         try:
             from sidepulse import status_bar
         except SystemExit as exc:
             self.skipTest(str(exc))
 
-        settings = AgentMonitorSettings().with_dnd(manual_enabled=True)
+        settings = AgentMonitorSettings().with_dnd(
+            enabled=False,
+            schedule_enabled=True,
+            start_time="21:00",
+            end_time="07:00",
+        )
+        self.assertFalse(status_bar.dnd_is_active(settings, datetime(2026, 8, 17, 23, 0)))
+
+        settings = settings.with_dnd(enabled=True)
         self.assertTrue(status_bar.dnd_is_active(settings, datetime(2026, 8, 17, 12, 0)))
         self.assertIn("LEDs are off", status_bar.dnd_status_text(settings))
 
@@ -1751,7 +1785,7 @@ class AgentMonitorTests(unittest.TestCase):
         snapshot = SimpleNamespace(statuses=[], collected_at=datetime.now(timezone.utc))
         target = SimpleNamespace(
             settings=AgentMonitorSettings().with_dnd(
-                manual_enabled=True,
+                enabled=True,
                 schedule_enabled=True,
             ),
             closed_lid_awake=SimpleNamespace(last_error=None),
@@ -1765,7 +1799,7 @@ class AgentMonitorTests(unittest.TestCase):
         }
 
         self.assertIn("Do Not Disturb", by_title)
-        self.assertEqual(by_title["Turn DND On Manually"].state(), 1)
+        self.assertEqual(by_title["DND On"].state(), 1)
 
     def test_lid_animation_program_uses_device_brightness(self) -> None:
         try:
@@ -1841,7 +1875,7 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertIn("dnd_start_time", target.settings_fields)
         self.assertIn("dnd_end_time", target.settings_fields)
         self.assertIn("dnd_status", target.settings_fields)
-        self.assertIn("dnd_manual", target.settings_buttons)
+        self.assertIn("dnd_enabled", target.settings_buttons)
         self.assertIn("dnd_schedule", target.settings_buttons)
         self.assertIn("closed_animation_program", target.settings_fields)
         self.assertIn("closed_animation_duration", target.settings_fields)
@@ -4410,23 +4444,28 @@ class AgentMonitorTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             settings_path = Path(tmp) / "settings.json"
             settings = AgentMonitorSettings().with_dnd(
-                manual_enabled=True,
+                enabled=True,
                 schedule_enabled=True,
                 start_time="21:30",
                 end_time="6:15",
+                schedule_transition="2026-08-17:start:21:30",
             )
 
             save_settings(settings, settings_path)
             loaded = load_settings(settings_path)
 
-            self.assertTrue(loaded.dnd_manual_enabled)
+            self.assertTrue(loaded.dnd_enabled)
             self.assertTrue(loaded.dnd_schedule_enabled)
             self.assertEqual(loaded.dnd_start_time, "21:30")
             self.assertEqual(loaded.dnd_end_time, "06:15")
+            self.assertEqual(
+                loaded.dnd_last_schedule_transition,
+                "2026-08-17:start:21:30",
+            )
 
     def test_settings_dnd_defaults_and_validation(self) -> None:
         settings = AgentMonitorSettings()
-        self.assertFalse(settings.dnd_manual_enabled)
+        self.assertFalse(settings.dnd_enabled)
         self.assertFalse(settings.dnd_schedule_enabled)
         self.assertEqual(settings.dnd_start_time, DEFAULT_DND_START_TIME)
         self.assertEqual(settings.dnd_end_time, DEFAULT_DND_END_TIME)
@@ -4434,6 +4473,17 @@ class AgentMonitorTests(unittest.TestCase):
             settings.with_dnd(start_time="25:00")
         with self.assertRaises(ValueError):
             settings.with_dnd(end_time="night")
+
+    def test_settings_migrates_legacy_manual_dnd_toggle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_path = Path(tmp) / "settings.json"
+            settings_path.write_text(
+                json.dumps({"do_not_disturb": {"manual_enabled": True}})
+            )
+
+            loaded = load_settings(settings_path)
+
+            self.assertTrue(loaded.dnd_enabled)
 
     def test_settings_migrates_missing_agent_list_timing_to_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -115,6 +115,8 @@ from sidepulse.settings import (
     CLOSED_LID_AWAKE_AGENTS,
     CLOSED_LID_AWAKE_ALWAYS,
     CLOSED_LID_AWAKE_NEVER,
+    DEFAULT_DND_END_TIME,
+    DEFAULT_DND_START_TIME,
     DEFAULT_IDLE_TIMEOUT_SECONDS,
     DEFAULT_HISTORY_TIMEFRAME_SECONDS,
     DEFAULT_RECENT_SESSION_RETENTION_SECONDS,
@@ -1552,6 +1554,7 @@ class AgentMonitorTests(unittest.TestCase):
             brightness=128,
         )
         fake = SimpleNamespace(
+            settings=AgentMonitorSettings(),
             status_bar_devices=lambda remember=True: [device],
             ensure_device_selection=lambda: None,
             last_led_error="old",
@@ -1681,6 +1684,89 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertNotIn("Sleep Helper Missing", titles)
         self.assertIn("Setup...", titles)
 
+    def test_dnd_schedule_handles_overnight_and_daytime_ranges(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        overnight = AgentMonitorSettings().with_dnd(
+            schedule_enabled=True,
+            start_time="22:00",
+            end_time="07:00",
+        )
+        self.assertTrue(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 23, 0)))
+        self.assertTrue(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 6, 59)))
+        self.assertFalse(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 7, 0)))
+        self.assertFalse(status_bar.dnd_is_active(overnight, datetime(2026, 8, 17, 12, 0)))
+
+        daytime = overnight.with_dnd(start_time="09:00", end_time="17:00")
+        self.assertTrue(status_bar.dnd_is_active(daytime, datetime(2026, 8, 17, 12, 0)))
+        self.assertFalse(status_bar.dnd_is_active(daytime, datetime(2026, 8, 17, 18, 0)))
+
+    def test_manual_dnd_overrides_schedule(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        settings = AgentMonitorSettings().with_dnd(manual_enabled=True)
+        self.assertTrue(status_bar.dnd_is_active(settings, datetime(2026, 8, 17, 12, 0)))
+        self.assertIn("LEDs are off", status_bar.dnd_status_text(settings))
+
+    def test_dnd_writes_off_once_per_physical_device(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        device = status_bar.StatusBarDevice(
+            device_id="/Volumes/SidePulseDot",
+            name="SidePulse Dot",
+            root=Path("/Volumes/SidePulseDot"),
+            target=Path("/Volumes/SidePulseDot/LEDS.LED"),
+            connected=True,
+            display="agent",
+        )
+        fake = SimpleNamespace(
+            status_bar_devices=lambda: [device],
+            dnd_off_targets=set(),
+            device_errors={},
+            last_led_error=None,
+        )
+        with patch("sidepulse.status_bar.write_led_program", return_value=device.target) as write:
+            status_bar.StatusBarController.sync_dnd_leds_now(fake)
+            status_bar.StatusBarController.sync_dnd_leds_now(fake)
+
+        write.assert_called_once_with("off", device_path=device.target)
+        self.assertEqual(fake.dnd_off_targets, {str(device.target)})
+        self.assertIsNone(fake.last_led_error)
+
+    def test_status_bar_menu_shows_dnd_toggle_and_schedule(self) -> None:
+        try:
+            from sidepulse import status_bar
+        except SystemExit as exc:
+            self.skipTest(str(exc))
+
+        snapshot = SimpleNamespace(statuses=[], collected_at=datetime.now(timezone.utc))
+        target = SimpleNamespace(
+            settings=AgentMonitorSettings().with_dnd(
+                manual_enabled=True,
+                schedule_enabled=True,
+            ),
+            closed_lid_awake=SimpleNamespace(last_error=None),
+            status_bar_devices=lambda: [],
+        )
+        menu = status_bar.build_menu(snapshot, status_bar.STATE_IDLE, target)
+        by_title = {
+            menu.itemAtIndex_(index).title(): menu.itemAtIndex_(index)
+            for index in range(menu.numberOfItems())
+            if menu.itemAtIndex_(index).title()
+        }
+
+        self.assertIn("Do Not Disturb", by_title)
+        self.assertEqual(by_title["Turn DND On Manually"].state(), 1)
+
     def test_lid_animation_program_uses_device_brightness(self) -> None:
         try:
             from sidepulse import status_bar
@@ -1752,6 +1838,11 @@ class AgentMonitorTests(unittest.TestCase):
         self.assertIn("idle_timeout_minutes", target.settings_fields)
         self.assertIn("sleep_prevention_min_battery_percent", target.settings_fields)
         self.assertIn("status_history_timeframe", target.settings_fields)
+        self.assertIn("dnd_start_time", target.settings_fields)
+        self.assertIn("dnd_end_time", target.settings_fields)
+        self.assertIn("dnd_status", target.settings_fields)
+        self.assertIn("dnd_manual", target.settings_buttons)
+        self.assertIn("dnd_schedule", target.settings_buttons)
         self.assertIn("closed_animation_program", target.settings_fields)
         self.assertIn("closed_animation_duration", target.settings_fields)
         self.assertIn("open_animation_program", target.settings_fields)
@@ -4314,6 +4405,35 @@ class AgentMonitorTests(unittest.TestCase):
             )
             self.assertEqual(loaded.recent_session_retention_seconds, 36 * 60 * 60)
             self.assertEqual(loaded.idle_timeout_seconds, 15 * 60)
+
+    def test_settings_round_trip_dnd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_path = Path(tmp) / "settings.json"
+            settings = AgentMonitorSettings().with_dnd(
+                manual_enabled=True,
+                schedule_enabled=True,
+                start_time="21:30",
+                end_time="6:15",
+            )
+
+            save_settings(settings, settings_path)
+            loaded = load_settings(settings_path)
+
+            self.assertTrue(loaded.dnd_manual_enabled)
+            self.assertTrue(loaded.dnd_schedule_enabled)
+            self.assertEqual(loaded.dnd_start_time, "21:30")
+            self.assertEqual(loaded.dnd_end_time, "06:15")
+
+    def test_settings_dnd_defaults_and_validation(self) -> None:
+        settings = AgentMonitorSettings()
+        self.assertFalse(settings.dnd_manual_enabled)
+        self.assertFalse(settings.dnd_schedule_enabled)
+        self.assertEqual(settings.dnd_start_time, DEFAULT_DND_START_TIME)
+        self.assertEqual(settings.dnd_end_time, DEFAULT_DND_END_TIME)
+        with self.assertRaises(ValueError):
+            settings.with_dnd(start_time="25:00")
+        with self.assertRaises(ValueError):
+            settings.with_dnd(end_time="night")
 
     def test_settings_migrates_missing_agent_list_timing_to_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_status_bar_ui.py
+++ b/tests/test_status_bar_ui.py
@@ -376,6 +376,14 @@ class WindowBuildTests(StatusBarTestCase):
             self.controller.settings_fields,
             "settings window built no addressable fields; saving would be a no-op",
         )
+        for key in (
+            "dnd_start_time",
+            "dnd_end_time",
+            "dnd_status",
+        ):
+            self.assertIn(key, self.controller.settings_fields)
+        self.assertIn("dnd_manual", self.controller.settings_buttons)
+        self.assertIn("dnd_schedule", self.controller.settings_buttons)
 
     def test_settings_window_is_not_visible(self):
         window = sb.build_settings_window(self.controller)

--- a/tests/test_status_bar_ui.py
+++ b/tests/test_status_bar_ui.py
@@ -382,8 +382,9 @@ class WindowBuildTests(StatusBarTestCase):
             "dnd_status",
         ):
             self.assertIn(key, self.controller.settings_fields)
-        self.assertIn("dnd_manual", self.controller.settings_buttons)
+        self.assertIn("dnd_enabled", self.controller.settings_buttons)
         self.assertIn("dnd_schedule", self.controller.settings_buttons)
+        self.assertTrue(self.controller.settings_buttons["dnd_enabled"].isEnabled())
 
     def test_settings_window_is_not_visible(self):
         window = sb.build_settings_window(self.controller)


### PR DESCRIPTION
Split out of #22.

- **Do Not Disturb** toggle in the menu-bar dropdown, plus a daily schedule (start/end time) in Settings
- The schedule drives the toggle: DND turns on at the start time and off at the end time, and a manual override at any time is respected until the next scheduled transition
- While DND is active the LEDs stay dark

Covered by settings round-trip, schedule-transition, and settings-window tests; full suite passes.