### PR TITLE
Turn LEDs off when idle and add a KITT scanner mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,25 @@ Agent status modes:
 | Mode | Meaning | LED pattern |
 | --- | --- | --- |
 | Idle / Ready | The agent is available and not currently running a task. | Off. |
-| Working | The agent is thinking, generating, or otherwise actively processing. | Cyan rolling animation. |
-| Tool Running | A shell command, API call, or external tool is in progress. | Cyan rolling animation. |
+| Working | The agent is thinking, generating, or otherwise actively processing. | Cyan rolling animation, or a bidirectional KITT scanner when enabled. |
+| Tool Running | A shell command, API call, or external tool is in progress. | Cyan rolling animation, or a bidirectional KITT scanner when enabled. |
 | Waiting for Input | The agent needs a user decision, approval, or additional context. | Slow amber pulse. |
-| Long Task Progress | A longer job has measurable progress. | Cyan rolling animation. |
+| Long Task Progress | A longer job has measurable progress. | Cyan rolling animation, or a bidirectional KITT scanner when enabled. |
 | Blocked / Error | The agent cannot continue, a tool failed, or a recoverable error needs attention. | Slow amber pulse. |
 | Completed | The agent finished successfully. | Solid green. |
 
 When multiple states are active, SidePulse should show the most actionable
 mode first: Blocked / Error, Waiting for Input, Tool Running, Long Task
 Progress, Working, then Idle / Ready.
+
+### KITT scanner
+
+Enable **KITT scanner while working** from the menu-bar dropdown or from
+**Settings... → Devices & LEDs**. Working, Tool Running, and Long Task Progress
+then sweep back and forth like KITT while keeping the normal working-state color
+and each device's configured brightness. Ask, Done, Idle, battery, and custom
+displays are unchanged. The animation adapts to both the eight-LED SidePulse Pro
+and two-LED SidePulse Dot.
 
 For multiple agents, SidePulse aggregates their statuses into one global
 display state. Each agent reports its own mode, and SidePulse renders the

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Agent status modes:
 
 | Mode | Meaning | LED pattern |
 | --- | --- | --- |
-| Idle / Ready | The agent is available and not currently running a task. | Very dim idle pulse. |
+| Idle / Ready | The agent is available and not currently running a task. | Off. |
 | Working | The agent is thinking, generating, or otherwise actively processing. | Cyan rolling animation. |
 | Tool Running | A shell command, API call, or external tool is in progress. | Cyan rolling animation. |
 | Waiting for Input | The agent needs a user decision, approval, or additional context. | Slow amber pulse. |
@@ -322,9 +322,8 @@ Working.
 
 `Completed` remains visible for 20 minutes so the status bar and LEDs can show
 Done long enough to be noticed. After that it drops out instead of counting as
-an active session for the full stale window, and the LEDs return to the very
-dim Idle pattern. Idle/session-start records also do not count as active
-sessions.
+an active session for the full stale window, and the LEDs turn off. Idle/session-start
+records also do not count as active sessions.
 
 Status detection is strongest when the agent tells the monitor its intended
 handoff state explicitly. A final assistant message can include a hidden marker

--- a/src/sidepulse/led_status.py
+++ b/src/sidepulse/led_status.py
@@ -32,7 +32,6 @@ LED_STATE_LABELS: dict[LedDisplayState, str] = {
 ASK_AMBER = "#FF3A00"
 WORKING_CYAN = "#00E5FF"
 DONE_GREEN = "#00FF66"
-IDLE_DIM = "#020204"
 DEVICE_LED_COUNTS = {
     "sidepulsedot": 2,
     "sidepulsepro": 8,
@@ -73,16 +72,7 @@ def program_for_display_state(
     brightness: int | float = 255,
 ) -> str:
     if state == LedDisplayState.IDLE:
-        return apply_brightness(
-            "\n".join(
-                [
-                    "off",
-                    f"{IDLE_DIM} 6s pulse",
-                    "repeat",
-                ]
-            ),
-            brightness,
-        )
+        return "off"
     if state == LedDisplayState.ASK:
         return apply_brightness(
             "\n".join(

--- a/src/sidepulse/led_status.py
+++ b/src/sidepulse/led_status.py
@@ -70,6 +70,7 @@ def program_for_display_state(
     *,
     led_count: int = 8,
     brightness: int | float = 255,
+    kitt_mode: bool = False,
 ) -> str:
     if state == LedDisplayState.IDLE:
         return "off"
@@ -87,7 +88,12 @@ def program_for_display_state(
     if state == LedDisplayState.DONE:
         return apply_brightness(DONE_GREEN, brightness)
     if state == LedDisplayState.WORKING:
-        return apply_brightness(rolling_program(WORKING_CYAN, led_count=led_count), brightness)
+        program = (
+            kitt_scanner_program(WORKING_CYAN, led_count=led_count)
+            if kitt_mode
+            else rolling_program(WORKING_CYAN, led_count=led_count)
+        )
+        return apply_brightness(program, brightness)
     raise ValueError(f"Unknown LED display state: {state}")
 
 
@@ -108,6 +114,28 @@ def rolling_program(color: str, *, led_count: int = 8) -> str:
     )
 
 
+def kitt_scanner_program(color: str, *, led_count: int = 8) -> str:
+    """Build a compact KITT-style pulse that scans out and back."""
+    count = max(2, min(8, int(led_count)))
+    delay_ms = 240 if count == 2 else 85
+    duration_ms = 320
+    directions = (range(count), range(count - 2, -1, -1))
+    scan_lines = [
+        "; ".join(
+            f"{index}:{color} {duration_ms}ms pulse {step * delay_ms}ms"
+            for step, index in enumerate(indexes)
+        )
+        for indexes in directions
+    ]
+    return "\n".join(
+        [
+            "off 80ms cosine",
+            *scan_lines,
+            "repeat",
+        ]
+    )
+
+
 def write_mode_to_leds(
     mode: AgentMode,
     *,
@@ -115,6 +143,7 @@ def write_mode_to_leds(
     file_name: str = DEFAULT_FILE_NAME,
     dry_run: bool = False,
     brightness: int | float = 255,
+    kitt_mode: bool = False,
 ) -> LedStatusWrite:
     target = resolve_target_path(device_path=device_path, file_name=file_name)
     state = display_state_for_mode(mode)
@@ -122,6 +151,7 @@ def write_mode_to_leds(
         state,
         led_count=led_count_for_target(target),
         brightness=brightness,
+        kitt_mode=kitt_mode,
     )
     written_target = write_led_program(
         program,
@@ -183,6 +213,7 @@ class AgentLedController:
         self.brightness = normalize_brightness(brightness)
         self.last_state: LedDisplayState | None = None
         self.last_brightness: int | None = None
+        self.last_kitt_mode: bool | None = None
         self.last_error: str | None = None
         self.last_target: Path | None = None
         self.last_attempt_monotonic = 0.0
@@ -190,15 +221,22 @@ class AgentLedController:
     def reset(self) -> None:
         self.last_state = None
         self.last_brightness = None
+        self.last_kitt_mode = None
         self.last_error = None
         self.last_target = None
         self.last_attempt_monotonic = 0.0
 
-    def sync_mode(self, mode: AgentMode) -> LedStatusWrite:
+    def sync_mode(self, mode: AgentMode, *, kitt_mode: bool = False) -> LedStatusWrite:
         state = display_state_for_mode(mode)
         brightness = normalize_brightness(self.brightness)
+        kitt_mode = bool(kitt_mode)
         now = time.monotonic()
-        if state == self.last_state and brightness == self.last_brightness and self.last_error is None:
+        if (
+            state == self.last_state
+            and brightness == self.last_brightness
+            and kitt_mode == self.last_kitt_mode
+            and self.last_error is None
+        ):
             return LedStatusWrite(
                 state=state,
                 target=self.last_target,
@@ -208,6 +246,7 @@ class AgentLedController:
         if (
             state == self.last_state
             and brightness == self.last_brightness
+            and kitt_mode == self.last_kitt_mode
             and self.last_error is not None
             and now - self.last_attempt_monotonic < self.error_retry_seconds
         ):
@@ -227,10 +266,12 @@ class AgentLedController:
                 file_name=self.file_name,
                 dry_run=self.dry_run,
                 brightness=brightness,
+                kitt_mode=kitt_mode,
             )
         except (DeviceWriteError, OSError) as exc:
             self.last_state = state
             self.last_brightness = brightness
+            self.last_kitt_mode = kitt_mode
             self.last_error = str(exc)
             return LedStatusWrite(
                 state=state,
@@ -242,6 +283,7 @@ class AgentLedController:
 
         self.last_state = state
         self.last_brightness = brightness
+        self.last_kitt_mode = kitt_mode
         self.last_error = None
         self.last_target = result.target
         return result

--- a/src/sidepulse/settings.py
+++ b/src/sidepulse/settings.py
@@ -148,6 +148,7 @@ class AgentMonitorSettings:
     )
     battery_full_charge_watts: float | None = None
     battery_show_on_power_change: bool = True
+    kitt_mode_enabled: bool = False
     battery_power_change_preview_seconds: float = DEFAULT_POWER_CHANGE_PREVIEW_SECONDS
     session_open_preferences: dict[str, str] = field(default_factory=dict)
     grok_session_open_action: str = SESSION_OPEN_TERMINAL
@@ -424,6 +425,9 @@ class AgentMonitorSettings:
             return replace(self, lid_open_animation=animation)
         raise ValueError(f"Unknown lid animation: {kind}")
 
+    def with_kitt_mode(self, enabled: bool) -> "AgentMonitorSettings":
+        return replace(self, kitt_mode_enabled=bool(enabled))
+
     def with_setup_screen_completed(self, completed: bool = True) -> "AgentMonitorSettings":
         return replace(self, setup_screen_completed=bool(completed))
 
@@ -491,6 +495,7 @@ class AgentMonitorSettings:
             "history": {
                 "timeframe_seconds": self.history_timeframe_seconds,
             },
+            "kitt_mode_enabled": self.kitt_mode_enabled,
             "setup_screen_completed": self.setup_screen_completed,
         }
 
@@ -621,6 +626,7 @@ def load_settings(path: Path | None = None) -> AgentMonitorSettings:
                 data.get("history_timeframe_seconds", DEFAULT_HISTORY_TIMEFRAME_SECONDS),
             )
         ),
+        kitt_mode_enabled=_bool_setting(data.get("kitt_mode_enabled"), False),
         setup_screen_completed=_bool_setting(data.get("setup_screen_completed"), False),
     )
 

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -719,6 +719,14 @@ class StatusBarController(NSObject):
         self.set_battery_power_preview(sender.state() == NSOnState)
 
     @objc.IBAction
+    def toggleKittMode_(self, _sender):
+        self.set_kitt_mode(not self.settings.kitt_mode_enabled)
+
+    @objc.IBAction
+    def setKittModeFromCheckbox_(self, sender):
+        self.set_kitt_mode(sender.state() == NSOnState)
+
+    @objc.IBAction
     def saveAgentListTiming_(self, _sender):
         self.save_agent_list_timing_from_fields()
 
@@ -1035,6 +1043,10 @@ class StatusBarController(NSObject):
         set_checkbox_state(
             self.settings_buttons.get("battery_power_preview"),
             self.settings.battery_show_on_power_change,
+        )
+        set_checkbox_state(
+            self.settings_buttons.get("kitt_mode"),
+            self.settings.kitt_mode_enabled,
         )
         for provider in ("codex", "claude", "grok"):
             popup = self.settings_fields.get(f"{provider}_session_opener")
@@ -1589,6 +1601,23 @@ class StatusBarController(NSObject):
         self.refresh_settings_window()
         self.refresh_(None)
 
+    def set_kitt_mode(self, enabled: bool) -> None:
+        try:
+            self.settings = self.settings.with_kitt_mode(enabled)
+            save_settings(self.settings)
+        except Exception as exc:
+            self.set_settings_message(f"Could not save KITT mode: {exc}")
+            self.settings = load_settings()
+            self.refresh_settings_window()
+            return
+
+        self.reset_led_controllers_for_display_change()
+        self.set_settings_message(
+            f"KITT scanner {'enabled' if enabled else 'disabled'} for active agents."
+        )
+        self.refresh_settings_window()
+        self.refresh_(None)
+
     def read_battery_snapshot(self) -> BatterySnapshot | None:
         try:
             snapshot = read_battery_snapshot(
@@ -1897,6 +1926,7 @@ class StatusBarController(NSObject):
                     display_state_for_mode(mode),
                     led_count=8,
                     brightness=device.brightness,
+                    kitt_mode=self.settings.kitt_mode_enabled,
                 )
             )
 
@@ -1953,7 +1983,10 @@ class StatusBarController(NSObject):
                     f"{format_watts(battery_snapshot.adapter_power)}"
                 )
             else:
-                result = self.agent_controller_for_device(device).sync_mode(mode)
+                result = self.agent_controller_for_device(device).sync_mode(
+                    mode,
+                    kitt_mode=self.settings.kitt_mode_enabled,
+                )
                 label = f"{device.name} {result.label}"
 
             if result.error:
@@ -2318,6 +2351,15 @@ def build_menu(snapshot, state: StatusBarState, target: StatusBarController) -> 
         )
         virtual_toggle.setTarget_(target)
         menu.addItem_(virtual_toggle)
+
+    kitt_mode = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+        "KITT Scanner While Working",
+        "toggleKittMode:",
+        "",
+    )
+    kitt_mode.setTarget_(target)
+    kitt_mode.setState_(1 if target.settings.kitt_mode_enabled else 0)
+    menu.addItem_(kitt_mode)
 
     menu.addItem_(NSMenuItem.separatorItem())
     menu.addItem_(disabled_menu_item("Closed-Lid Sleep Prevention"))
@@ -3317,6 +3359,16 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         target,
         "setBatteryPowerPreviewFromCheckbox:",
     )
+    kitt_mode = add_checkbox(
+        devices_tab,
+        "KITT scanner while working",
+        344,
+        356,
+        280,
+        24,
+        target,
+        "setKittModeFromCheckbox:",
+    )
 
     add_label(sleep_tab, "Lid Closed", 24, 398, 120, 22)
     add_label(sleep_tab, "Duration", 516, 398, 70, 22)
@@ -3402,6 +3454,7 @@ def build_settings_window(target: StatusBarController) -> NSWindow:
         "claude_transcripts": claude_transcripts,
         "battery_leds": battery_leds,
         "battery_power_preview": battery_power_preview,
+        "kitt_mode": kitt_mode,
     }
     return window
 

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -3537,7 +3537,7 @@ class AgentMonitorTests(unittest.TestCase):
 
         self.assertEqual(
             program_for_display_state(LedDisplayState.IDLE),
-            "off\n#020204 6s pulse\nrepeat",
+            "off",
         )
         self.assertEqual(program_for_display_state(LedDisplayState.DONE), "#00FF66")
         self.assertIn("#FF3A00 1.6s pulse", program_for_display_state(LedDisplayState.ASK))
@@ -3578,7 +3578,7 @@ class AgentMonitorTests(unittest.TestCase):
 
             self.assertEqual(
                 (device / "LEDS.LED").read_text(),
-                "off\n#020204 6s pulse\nrepeat",
+                "off",
             )
 
             write_mode_to_leds(AgentMode.COMPLETED, device_path=device, brightness=64)

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -3553,6 +3553,21 @@ class AgentMonitorTests(unittest.TestCase):
             len(program_for_display_state(LedDisplayState.WORKING, led_count=8).splitlines()),
             3,
         )
+        kitt_program = program_for_display_state(
+            LedDisplayState.WORKING,
+            led_count=8,
+            brightness=128,
+            kitt_mode=True,
+        )
+        validate_led_text(kitt_program)
+        self.assertLessEqual(len(kitt_program.encode("utf-8")), 512)
+        kitt_lines = kitt_program.splitlines()
+        self.assertIn("7:#00E5FF 320ms pulse 595ms", kitt_lines[2])
+        self.assertIn("6:#00E5FF 320ms pulse 0ms", kitt_lines[3])
+        self.assertIn("0:#00E5FF 320ms pulse 510ms", kitt_lines[3])
+        self.assertEqual(kitt_lines[2].count("7:#00E5FF"), 1)
+        self.assertEqual(kitt_lines[3].count("7:#00E5FF"), 0)
+        self.assertTrue(kitt_program.endswith("repeat"))
         self.assertEqual(
             program_for_display_state(LedDisplayState.DONE, brightness=128),
             "brightness 128\n#00FF66",
@@ -3618,6 +3633,24 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertFalse(second.changed)
             self.assertTrue(third.changed)
             self.assertIn("#FF3A00 1.6s pulse", (device / "LEDS.LED").read_text())
+
+    def test_agent_led_controller_rewrites_working_state_when_kitt_mode_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            device = Path(tmp) / "SidePulsePro"
+            device.mkdir()
+            controller = AgentLedController(device_path=device)
+
+            standard = controller.sync_mode(AgentMode.WORKING)
+            kitt = controller.sync_mode(AgentMode.WORKING, kitt_mode=True)
+            unchanged = controller.sync_mode(AgentMode.WORKING, kitt_mode=True)
+
+            self.assertTrue(standard.changed)
+            self.assertTrue(kitt.changed)
+            self.assertFalse(unchanged.changed)
+            program = (device / "LEDS.LED").read_text()
+            self.assertIn("7:#00E5FF 320ms pulse 595ms", program)
+            self.assertIn("6:#00E5FF 320ms pulse 0ms", program)
+            self.assertIn("0:#00E5FF 320ms pulse 510ms", program)
 
     def test_battery_parser_uses_adapter_watts_and_raw_capacity(self) -> None:
         payload = plistlib.dumps(
@@ -4292,6 +4325,17 @@ class AgentMonitorTests(unittest.TestCase):
                 )
                 self.assertEqual(save_settings(saved), settings_path)
                 self.assertEqual(load_settings(), saved)
+
+    def test_settings_round_trip_kitt_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_path = Path(tmp) / "settings.json"
+            settings = AgentMonitorSettings().with_kitt_mode(True)
+
+            save_settings(settings, settings_path)
+            loaded = load_settings(settings_path)
+
+            self.assertTrue(loaded.kitt_mode_enabled)
+            self.assertFalse(AgentMonitorSettings().kitt_mode_enabled)
 
     def test_settings_round_trip_agent_list_timing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Split out of #22. Two small LED behaviors:

- Idle no longer lights the LEDs — an idle machine goes dark instead of glowing
- An optional **KITT scanner** sweep for Working / Tool Running / Long Task Progress, toggled from the menu-bar dropdown or Settings → Devices & LEDs. It keeps the working-state color and per-device brightness, adapts to the eight-LED Pro and two-LED Dot, and leaves Ask, Done, Idle, battery, and custom displays unchanged

LED-program assertions and settings round-trip tests included; full suite passes.