### PR TITLE
Fix stale and stuck session states in the status bar

### DIFF
--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -1064,6 +1064,16 @@ def mode_for_event(record: HookEvent) -> AgentMode | None:
     if event in {"Stop", "SubagentStop"}:
         if _assistant_message_asks_question(raw.get("last_assistant_message")):
             return AgentMode.WAITING_FOR_INPUT
+        # The turn ended, but the harness reports background tasks still
+        # running (run_in_background shells, monitors) — the session is not
+        # done until they close, at which point the harness re-invokes the
+        # session and fresh events flow.
+        background_tasks = raw.get("background_tasks")
+        if isinstance(background_tasks, list) and any(
+            isinstance(task, dict) and task.get("status") == "running"
+            for task in background_tasks
+        ):
+            return AgentMode.LONG_TASK_PROGRESS
         return AgentMode.COMPLETED
     if event in {"SessionEnd"}:
         return AgentMode.COMPLETED

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -162,7 +162,14 @@ class AgentMonitor:
             else:
                 fresh.append(current)
 
-        if any(status_counts_active(status) for status in fresh):
+        # Only session-level rows may demote completed sessions to stale: an
+        # orphaned subagent row (its parent already done, its Stop event lost)
+        # would otherwise hide the parent's COMPLETED row from the aggregate
+        # and keep the overall state "working" forever.
+        if any(
+            status_counts_active(status) and ":agent:" not in status.agent_id
+            for status in fresh
+        ):
             inactive = [status for status in fresh if not status_counts_active(status)]
             fresh = [status for status in fresh if status_counts_active(status)]
             stale.extend(_replace_stale(status, True) for status in inactive)
@@ -1186,7 +1193,7 @@ def aggregate_status(
     # A subagent's activity is subsumed by its parent session, and an
     # orphaned subagent (parent already done) must not keep the overall
     # state "working"; drive the aggregate from session-level rows.
-    effective = tuple(s for s in statuses if ":agent:" not in s.agent_id) or statuses
+    effective = tuple(s for s in statuses if ":agent:" not in s.agent_id)
     if not effective:
         return AggregateStatus(
             mode=AgentMode.IDLE_READY,
@@ -1245,7 +1252,13 @@ def snapshot_from_statuses(
         else:
             fresh.append(current)
 
-    if any(status_counts_active(status) for status in fresh):
+    # Only session-level rows may demote completed sessions to stale (see the
+    # matching check in AgentMonitor.snapshot): an orphaned subagent row must
+    # not hide the parent's COMPLETED row from the aggregate.
+    if any(
+        status_counts_active(status) and ":agent:" not in status.agent_id
+        for status in fresh
+    ):
         inactive = [status for status in fresh if not status_counts_active(status)]
         fresh = [status for status in fresh if status_counts_active(status)]
         stale.extend(_replace_stale(status, True) for status in inactive)

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -217,6 +217,7 @@ class AgentMonitor:
                 ):
                     continue
                 statuses_by_key[status.agent_id] = status
+                complete_subagents_for_ended_session(record, statuses_by_key)
 
         self._latest_status_signature = signature
         self._latest_statuses_by_key = dict(statuses_by_key)
@@ -420,6 +421,7 @@ class LiveAgentMonitor:
             ):
                 return
             self.statuses_by_key[status.agent_id] = status
+            complete_subagents_for_ended_session(record, self.statuses_by_key)
             self.write_latest_state()
 
     def snapshot(self, include_stale: bool = False) -> MonitorSnapshot:
@@ -1329,6 +1331,27 @@ def agent_status_from_dict(data: object) -> AgentStatus | None:
 
 def status_counts_active(status: AgentStatus) -> bool:
     return status.mode not in {AgentMode.COMPLETED, AgentMode.IDLE_READY}
+
+
+def complete_subagents_for_ended_session(
+    record: HookEvent,
+    statuses_by_key: dict[str, AgentStatus],
+) -> None:
+    """Mark a session's subagent rows completed when the session itself ends.
+
+    SubagentStop rows are keyed by agent id, so a later SessionEnd for the parent
+    session would otherwise leave them visible until the generic stale timeout.
+    """
+    if record.event_name != "SessionEnd" or record.agent_id or not record.session_id:
+        return
+    for key, status in statuses_by_key.items():
+        if (
+            key != record.status_key
+            and status.provider == record.provider
+            and status.session_id == record.session_id
+            and status_counts_active(status)
+        ):
+            statuses_by_key[key] = _replace_mode(status, AgentMode.COMPLETED)
 
 
 def track_pending_permissions(

--- a/src/sidepulse/collector.py
+++ b/src/sidepulse/collector.py
@@ -1183,7 +1183,11 @@ def aggregate_status(
     statuses: tuple[AgentStatus, ...],
     stale_statuses: tuple[AgentStatus, ...] = (),
 ) -> AggregateStatus:
-    if not statuses:
+    # A subagent's activity is subsumed by its parent session, and an
+    # orphaned subagent (parent already done) must not keep the overall
+    # state "working"; drive the aggregate from session-level rows.
+    effective = tuple(s for s in statuses if ":agent:" not in s.agent_id) or statuses
+    if not effective:
         return AggregateStatus(
             mode=AgentMode.IDLE_READY,
             active_count=0,
@@ -1192,7 +1196,7 @@ def aggregate_status(
         )
 
     representative = min(
-        statuses,
+        effective,
         key=lambda status: (
             MODE_PRIORITY.get(status.mode, MODE_PRIORITY[AgentMode.UNKNOWN]),
             -status.updated_at.timestamp(),
@@ -1201,7 +1205,7 @@ def aggregate_status(
 
     return AggregateStatus(
         mode=representative.mode,
-        active_count=sum(1 for status in statuses if status_counts_active(status)),
+        active_count=sum(1 for status in effective if status_counts_active(status)),
         stale_count=len(stale_statuses),
         representative=representative,
     )

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -436,6 +436,15 @@ class StatusBarController(NSObject):
         button.setToolTip_("SidePulse Agent Monitor: Idle")
         log_status_bar("status item created")
 
+        # One persistent menu whose contents are rebuilt on demand: AppKit
+        # calls menuNeedsUpdate_ right before the menu is drawn, so what the
+        # user sees is always built from a fresh snapshot rather than the
+        # last periodic tick (which could be up to STATUS_BAR_REFRESH_SECONDS
+        # stale, and which AppKit ignores entirely while the menu is open).
+        self.menu = NSMenu.alloc().init()
+        self.menu.setDelegate_(self)
+        self.status_item.setMenu_(self.menu)
+
         self.refresh_(None)
         self.timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
             STATUS_BAR_REFRESH_SECONDS,
@@ -481,7 +490,6 @@ class StatusBarController(NSObject):
                 mac_sleep_snapshot,
             )
             self.sync_leds(AgentMode.BLOCKED_ERROR, battery_snapshot, LED_DISPLAY_AGENT)
-            self.status_item.setMenu_(build_error_menu(exc))
             return
 
         self.last_snapshot = snapshot
@@ -502,11 +510,32 @@ class StatusBarController(NSObject):
             battery_snapshot,
             self.active_led_display_kind(battery_snapshot),
         )
-        self.status_item.setMenu_(build_menu(snapshot, state, self))
 
     @objc.IBAction
     def forceRefresh_(self, _sender):
         self.refresh_(None)
+
+    def _fill_menu_from(self, source) -> None:
+        # Move the freshly built items into the live, delegate-owned menu.
+        # NSMenuItems can only belong to one menu, so detach then re-add.
+        self.menu.removeAllItems()
+        for item in list(source.itemArray()):
+            source.removeItem_(item)
+            self.menu.addItem_(item)
+
+    def rebuild_status_menu(self) -> None:
+        try:
+            snapshot = self.monitor.snapshot(include_stale=False)
+        except Exception as exc:
+            log_status_bar(f"menu rebuild error: {exc}")
+            self._fill_menu_from(build_error_menu(exc))
+            return
+        self.last_snapshot = snapshot
+        state = state_for_mode(snapshot.aggregate.mode)
+        self._fill_menu_from(build_menu(snapshot, state, self))
+
+    def menuNeedsUpdate_(self, menu) -> None:
+        self.rebuild_status_menu()
 
     @objc.IBAction
     def openDeepLink_(self, sender):

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -4250,7 +4250,10 @@ def recent_statuses(
 
 
 def menu_statuses(snapshot, settings=None) -> tuple[AgentStatus, ...]:
-    statuses = list(snapshot.statuses)
+    # Subagents (Task tool) surface as their own :agent: rows and often
+    # orphan in a running state when their parent session is still alive,
+    # duplicating the session; show session-level rows only.
+    statuses = [status for status in snapshot.statuses if ":agent:" not in status.agent_id]
     now = snapshot.collected_at
     retention_seconds = (
         settings.recent_session_retention_seconds
@@ -4261,6 +4264,7 @@ def menu_statuses(snapshot, settings=None) -> tuple[AgentStatus, ...]:
         status
         for status in getattr(snapshot, "stale_statuses", ())
         if status.mode == AgentMode.COMPLETED
+        and ":agent:" not in status.agent_id
         and status.age_seconds(now) <= retention_seconds
     )
     return tuple(statuses)

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -171,6 +171,27 @@ class FakeProcess:
 
 
 class AgentMonitorTests(unittest.TestCase):
+    def test_stop_with_running_background_tasks_is_long_task(self) -> None:
+        from sidepulse.collector import mode_for_event
+        from sidepulse.models import HookEvent
+
+        def stop(background):
+            return HookEvent(
+                provider="claude",
+                logged_at=datetime.now(timezone.utc),
+                event_name="Stop",
+                raw={"background_tasks": background},
+                session_id="s1",
+            )
+
+        running = [{"id": "b1", "type": "shell", "status": "running"}]
+        self.assertEqual(mode_for_event(stop(running)), AgentMode.LONG_TASK_PROGRESS)
+        self.assertEqual(mode_for_event(stop([])), AgentMode.COMPLETED)
+        self.assertEqual(
+            mode_for_event(stop([{"id": "b1", "status": "completed"}])),
+            AgentMode.COMPLETED,
+        )
+
     def test_aggregates_highest_priority_status(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -192,6 +192,57 @@ class AgentMonitorTests(unittest.TestCase):
             AgentMode.COMPLETED,
         )
 
+    def test_orphaned_subagent_does_not_keep_aggregate_working(self) -> None:
+        # A subagent whose Stop event was lost stays active forever; it must
+        # not drive the aggregate. While the parent's COMPLETED row is visible
+        # the aggregate is completed; once it ages out the aggregate goes
+        # idle rather than resurrecting the orphaned subagent as "working".
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            claude = base / "claude.jsonl"
+            claude.write_text(
+                json.dumps(
+                    {
+                        "logged_at": "2026-06-20T06:00:00Z",
+                        "hook_event_name": "SubagentStart",
+                        "session_id": "claude-session",
+                        "agent_id": "orphan-agent",
+                    }
+                )
+                + "\n"
+                + json.dumps(
+                    {
+                        "logged_at": "2026-06-20T06:05:00Z",
+                        "hook_event_name": "Stop",
+                        "session_id": "claude-session",
+                    }
+                )
+                + "\n"
+            )
+
+            visible = AgentMonitor(
+                sources=(SourceSpec("claude", claude),),
+                stale_after_seconds=999999999,
+                tool_running_timeout_seconds=0,
+                completed_visible_seconds=-1,
+            ).snapshot()
+            self.assertEqual(visible.aggregate.mode, AgentMode.COMPLETED)
+            session_rows = [
+                status
+                for status in visible.statuses
+                if ":agent:" not in status.agent_id
+            ]
+            self.assertEqual(len(session_rows), 1)
+            self.assertEqual(session_rows[0].mode, AgentMode.COMPLETED)
+
+            aged = AgentMonitor(
+                sources=(SourceSpec("claude", claude),),
+                stale_after_seconds=999999999,
+                tool_running_timeout_seconds=0,
+                completed_visible_seconds=60,
+            ).snapshot()
+            self.assertEqual(aged.aggregate.mode, AgentMode.IDLE_READY)
+
     def test_aggregates_highest_priority_status(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -606,6 +606,44 @@ class AgentMonitorTests(unittest.TestCase):
             self.assertEqual(reloaded.snapshot().aggregate.mode, AgentMode.TOOL_RUNNING)
             self.assertEqual(reloaded.snapshot().statuses[0].origin, "Codex UI")
 
+    def test_live_sidepulse_session_end_completes_lingering_subagents(self) -> None:
+        monitor = LiveAgentMonitor(stale_after_seconds=3600)
+        session_id = "03a6ef62-1ae1-49cc-b1fd-f9ebe272a677"
+        now = datetime.now(timezone.utc)
+
+        def ingest(event: dict[str, object]) -> None:
+            line = {
+                "logged_at": now.isoformat(),
+                "session_id": session_id,
+                "cwd": "/tmp/project",
+                **event,
+            }
+            record = parse_log_line("claude", json.dumps(line))
+            self.assertIsNotNone(record)
+            monitor.ingest_record(record)
+
+        ingest({"hook_event_name": "Stop", "last_assistant_message": "Done."})
+        ingest(
+            {
+                "hook_event_name": "SubagentStop",
+                "agent_id": "af896bde23bba0adc",
+                "last_assistant_message": "what about next week?",
+            }
+        )
+
+        modes = {s.agent_id: s.mode for s in monitor.snapshot().statuses}
+        self.assertEqual(
+            modes["claude:agent:af896bde23bba0adc"], AgentMode.WAITING_FOR_INPUT
+        )
+
+        ingest({"hook_event_name": "SessionEnd", "reason": "other"})
+
+        snapshot = monitor.snapshot(include_stale=True)
+        modes = {s.agent_id: s.mode for s in snapshot.statuses + snapshot.stale_statuses}
+        self.assertEqual(modes[f"claude:session:{session_id}"], AgentMode.COMPLETED)
+        self.assertEqual(modes["claude:agent:af896bde23bba0adc"], AgentMode.COMPLETED)
+        self.assertNotEqual(snapshot.aggregate.mode, AgentMode.WAITING_FOR_INPUT)
+
     def test_status_bar_startup_replay_ingests_recent_debug_logs(self) -> None:
         try:
             from sidepulse import status_bar


### PR DESCRIPTION
Split out of #22. A set of independent correctness fixes for session-state reporting:

- Classify Stop with running background tasks as long-task progress (the harness reports them in the hook payload; the session is not done until they close)
- Complete lingering subagent rows when their parent session ends
- Hide subagent rows from the status-bar menu and exclude them from the aggregate — a subagent's activity is subsumed by its parent session
- Never let an orphaned subagent row (its Stop event lost) drive the aggregate back to "working" after the parent completed
- Rebuild the status-bar menu in `menuNeedsUpdate:` so an open menu always reflects the current snapshot (AppKit ignores a menu swap while the menu is open)

Each fix has a regression test; full suite passes.