### PR TITLE
Let the display sleep during keep-awake

### DIFF
--- a/src/sidepulse/keep_awake.py
+++ b/src/sidepulse/keep_awake.py
@@ -15,7 +15,7 @@ AWAKE_GRACE_SECONDS = 300.0
 SD_STATUS_READ_SECONDS = 60.0
 KEEPALIVE_FILE_NAME = "keepalive"
 STATUS_FILE_NAME = KEEPALIVE_FILE_NAME
-CAFFEINATE_COMMAND = ("/usr/bin/caffeinate", "-dimsu")
+CAFFEINATE_COMMAND = ("/usr/bin/caffeinate", "-imsu")
 
 
 class KeepAwakeController:

--- a/src/sidepulse/lid_sleep.py
+++ b/src/sidepulse/lid_sleep.py
@@ -17,7 +17,7 @@ from .settings import (
 )
 
 
-CAFFEINATE_CLOSED_LID_COMMAND = ("/usr/bin/caffeinate", "-dimsu")
+CAFFEINATE_CLOSED_LID_COMMAND = ("/usr/bin/caffeinate", "-imsu")
 IOREG_CLAMSHELL_COMMAND = ("/usr/sbin/ioreg", "-r", "-k", "AppleClamshellState", "-d", "4")
 IOREG_SLEEP_DISABLED_COMMAND = ("/usr/sbin/ioreg", "-r", "-k", "SleepDisabled", "-d", "4")
 PMSET_ASSERTIONS_COMMAND = ("/usr/bin/pmset", "-g", "assertions")


### PR DESCRIPTION
Split out of #22. Drops `-d` from the `caffeinate` invocations so keep-awake prevents system sleep without forcing the display to stay on.