### PR TITLE
Run agent hooks off the critical path

### DIFF
--- a/src/sidepulse/install.py
+++ b/src/sidepulse/install.py
@@ -314,7 +314,20 @@ def hook_command(
 
 
 def fail_open_command(command: str) -> str:
-    return f"{command} ; true"
+    # Run the hook off the agent's critical path.
+    #
+    # Drain stdin in the foreground shell first: the detached child cannot read
+    # it, because the agent closes the pipe as soon as this command returns.
+    #
+    # The child's stdio MUST be redirected to /dev/null. A bare "&" is not
+    # enough -- the child inherits the stdout pipe, and the agent blocks
+    # reading that pipe until EOF, which only arrives when the child exits.
+    # Backgrounding without closing stdio measures identical to running
+    # synchronously.
+    #
+    # printf, never echo: hook payloads are JSON, and sh's builtin echo
+    # mangles the backslash escapes in tool_input/tool_response.
+    return f'P=$(cat); ( printf %s "$P" | {command} >/dev/null 2>&1 & ) ; true'
 
 
 def grok_legacy_hook_config_paths(config: Path) -> tuple[Path, ...]:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import subprocess
+import time
 import sys
 import tempfile
 import textwrap
@@ -351,8 +352,15 @@ class CleanInstallTests(unittest.TestCase):
             env=self.env(), cwd=str(self.home),
         )
         self.assertEqual(0, run.returncode, run.stderr)
+        # The hook is detached, so it returns before the child has logged.
+        # Poll rather than asserting immediately -- the guarantee is that the
+        # write lands, not that it has landed by the time the agent resumes.
+        log_path = self.home / "installed-hook.jsonl"
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not log_path.exists():
+            time.sleep(0.05)
         self.assertTrue(
-            (self.home / "installed-hook.jsonl").exists(),
+            log_path.exists(),
             f"the command written into agent configs logged nothing: {command}",
         )
 

--- a/tests/test_hook_stability.py
+++ b/tests/test_hook_stability.py
@@ -20,6 +20,7 @@ import io
 import json
 import os
 import subprocess
+import time
 import sys
 import tempfile
 import unittest
@@ -495,6 +496,10 @@ class InstalledCommandTests(unittest.TestCase):
             env={**os.environ, "SIDEPULSE_DISABLE_EVENT_SOCKET": "1"},
         )
         self.assertEqual(0, result.returncode, result.stderr)
+        # Detached hook: the command returns before the child logs, so poll.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not log_path.exists():
+            time.sleep(0.05)
         self.assertTrue(log_path.exists(), "installed hook command wrote nothing")
 
     def test_fail_open_wrapper_neutralizes_failure(self):

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -4647,8 +4647,10 @@ class AgentMonitorTests(unittest.TestCase):
 
         self.assertEqual(
             command,
+            'P=$(cat); ( printf %s "$P" | '
             f"{sys.executable} agent-monitor hook-log --provider codex "
-            "--log '/tmp/codex events.jsonl' ; true",
+            "--log '/tmp/codex events.jsonl'"
+            ' >/dev/null 2>&1 & ) ; true',
         )
 
     def test_hook_command_is_fail_open(self) -> None:


### PR DESCRIPTION
Hooks are registered on `PreToolUse` and `PostToolUse` with matcher `*`, so every tool call an agent makes pays two Python interpreter startups while it waits. On my machine that is ~44ms each — roughly **90ms of added latency per tool call**.

Nothing about the hook needs to be synchronous. `hook_log_main` writes a log line and makes a best-effort socket delivery; it prints nothing to stdout and always exits 0. The agent is waiting for a side effect it never reads.

This detaches it in `fail_open_command`, so all three providers inherit the change.

## Measured

Same payload, driven through the pipe-capturing subprocess call the agents actually use:

| | latency |
|---|---|
| synchronous (before) | 43.8ms |
| naive `cmd &` | 43.7ms |
| **detached, stdio closed (after)** | **5.4ms** |

## Two traps this avoids

**A bare `&` buys nothing.** The child inherits the stdout pipe, and the agent blocks reading that pipe until EOF — which only arrives when the child exits. It measures identical to synchronous. The child's stdio has to go to `/dev/null` so the pipe closes when the foreground shell returns.

**`printf`, not `echo`.** stdin must be drained in the foreground shell and handed to the child, because the agent closes the pipe as soon as the command returns. That hand-off cannot use `sh`'s builtin `echo`, which mangles backslash escapes — and hook payloads are JSON dense with them in `tool_input` / `tool_response`. Verified directly: with `echo` the payload fails to parse and every escaped event is logged as a `ParseError` record; with `printf %s` it round-trips intact.

## Tests

`291 passed, 376 subtests`.

Three tests encoded assumptions this changes:

- `test_installed_hook_command_points_at_the_installed_package` and `test_installed_command_actually_logs` asserted the log existed the instant the command returned. They now poll — the guarantee is that the write lands, not that it has landed before the agent resumes. (Confirmed it lands ~200ms later, no loss: 6 events fired, 6 landed, escapes intact.)
- `test_frozen_hook_command_uses_internal_cli` pinned the exact command string.

## Tradeoff

Hook events are no longer ordered with respect to each other. That is safe for the current consumer — the status bar samples current aggregate state rather than replaying a sequence, so a reordered pair converges on the next event. Flagging it in case anything later wants to treat these logs as an ordered stream.

Note that concurrent appends to a provider log already happened whenever two agents ran at once; this widens the window within a single agent rather than introducing the case.

Happy to adjust the shell form if you would rather express this differently.