### PR TITLE
Rate-limit LED writes and keep the trailing edge

### DIFF
--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -231,6 +231,11 @@ STATUS_BAR_KEEPALIVE_VOLUME_NAMES = (
 )
 STATUS_BAR_REFRESH_SECONDS = 15.0
 STATUS_BAR_DEVICE_POLL_SECONDS = 2.0
+# Minimum spacing between LED writes. Writes to a mounted SidePulse go to
+# SD/USB storage and are wildly variable -- measured 3ms best case, 2.7s
+# worst. Without a floor, every hook event triggers another write.
+LED_MIN_WRITE_INTERVAL_SECONDS = 1.0
+LED_DRAIN_POLL_SECONDS = 0.25
 STATUS_BAR_SESSION_HISTORY_LIMIT = 10
 SCREEN_BAR_FEATURE_ENABLED = True
 STATUS_BAR_MAX_LINES_PER_SOURCE = 500
@@ -395,6 +400,9 @@ class StatusBarController(NSObject):
         self.device_errors = {}
         self.leds_enabled = True
         self.led_sync_in_flight = False
+        self.led_last_sync_monotonic = 0.0
+        self.led_pending_sync = None
+        self.led_drain_timer = None
         self.last_led_error = None
         self.last_led_display_kind = LED_DISPLAY_AGENT
         self.last_connected_device_signature = None
@@ -455,6 +463,13 @@ class StatusBarController(NSObject):
             STATUS_BAR_DEVICE_POLL_SECONDS,
             self,
             "pollDevices:",
+            None,
+            True,
+        )
+        self.led_drain_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+            LED_DRAIN_POLL_SECONDS,
+            self,
+            "drainLedQueue:",
             None,
             True,
         )
@@ -1850,8 +1865,19 @@ class StatusBarController(NSObject):
         if time.monotonic() < self.led_animation_until_monotonic:
             return
 
+        # Coalesce: keep only the most recent state. Order of arrival does not
+        # matter because this samples current state rather than replaying a
+        # sequence -- which is what makes detached (async) hooks safe here.
         if self.led_sync_in_flight:
+            self.led_pending_sync = (mode, battery_snapshot, display_kind)
             return
+        if time.monotonic() - self.led_last_sync_monotonic < LED_MIN_WRITE_INTERVAL_SECONDS:
+            # Too soon. Stash it; the drain timer applies it on the trailing
+            # edge, so the final state of a burst is never dropped.
+            self.led_pending_sync = (mode, battery_snapshot, display_kind)
+            return
+
+        self.led_pending_sync = None
         self.led_sync_in_flight = True
         thread = threading.Thread(
             target=self.sync_leds_worker,
@@ -1859,6 +1885,15 @@ class StatusBarController(NSObject):
             daemon=True,
         )
         thread.start()
+
+    @objc.IBAction
+    def drainLedQueue_(self, _sender):
+        pending = self.led_pending_sync
+        if pending is None or self.led_sync_in_flight:
+            return
+        if time.monotonic() - self.led_last_sync_monotonic < LED_MIN_WRITE_INTERVAL_SECONDS:
+            return
+        self.sync_leds(*pending)
 
     def sync_virtual_status_device(
         self,
@@ -1909,6 +1944,7 @@ class StatusBarController(NSObject):
         try:
             self.sync_leds_now(mode, battery_snapshot, display_kind)
         finally:
+            self.led_last_sync_monotonic = time.monotonic()
             self.led_sync_in_flight = False
 
     def sync_leds_now(


### PR DESCRIPTION
Writing an LED program goes to the mounted device — SD or USB storage, and much slower and less predictable than it looks. Measured over repeated writes to a mounted SidePulse Pro:

| | |
|---|---|
| min | 3.0ms |
| avg | **549.6ms** |
| max | **2735.4ms** |

`sync_leds` guards against overlap with `led_sync_in_flight`, but that is a concurrency guard, not a rate limit — it is cleared the moment the write returns, so the next hook event starts another write immediately. Under a burst of agent events that is a sustained stream of writes with no minimum spacing, and it compounds with each additional agent.

This adds a 1s floor between writes.

## Why a drain timer rather than a throttle

A plain "drop if too soon" check would lose the final state of a burst: an event arriving 200ms after a write gets discarded, leaving the LEDs on a stale mode until something unrelated triggers a refresh. So the most recent state is stashed rather than dropped, and a drain timer applies it once the interval expires.

Coalescing to the latest state is safe here because this samples current aggregate state rather than replaying a sequence — an intermediate state that gets superseded within the same second was never going to be visible anyway.

The floor is measured from write *completion*, not write start, since it is the device that needs the breathing room.

## Side benefit

Device write traffic is now bounded independently of agent count. Previously N concurrent agents meant roughly N times the writes; verified aggregation already collapses N agents to one display state, so there was never a reason to write more often for more agents.

## Tests

`291 passed, 376 subtests`, verified with this branch installed on its own.

Happy to make the interval configurable in Settings instead of a constant if you would prefer that.