### PR TITLE
Read Control Center brightness via DisplayServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ https://github.com/user-attachments/assets/9de119ac-7b55-467f-8517-6c5f1570c1af
 
 The device mounts as a disk drive. You can control the LEDs by writing to `LEDS.LED`.
 
+LED brightness can follow the macOS Control Center slider (`system_brightness_ratio()`
+via DisplayServices). Do not use AppleARMBacklight's 16-bit `brightness` key — on
+current Macs it sits at 50% even when the slider is much lower.
+
 The LED control DSL is described in [`LEDS_FORMAT.md`](LEDS_FORMAT.md).
 
 ### TLDR

--- a/src/sidepulse/__init__.py
+++ b/src/sidepulse/__init__.py
@@ -13,6 +13,7 @@ from .ipc import (
     default_latest_state_path,
     send_hook_event,
 )
+from .display_brightness import system_brightness_ratio
 from .led_status import (
     AgentLedController,
     LedDisplayState,
@@ -61,6 +62,7 @@ __all__ = [
     "uninstall_sleep_helper",
     "send_hook_event",
     "program_for_display_state",
+    "system_brightness_ratio",
     "write_mode_to_leds",
 ]
 

--- a/src/sidepulse/display_brightness.py
+++ b/src/sidepulse/display_brightness.py
@@ -1,0 +1,71 @@
+"""Read the macOS display brightness the Control Center slider uses.
+
+AppleARMBacklight's 16-bit ``brightness`` key sits at 50% (32768/65536) on
+current Macs even when the slider is much lower, so LED mirroring must not
+use it. DisplayServices tracks the slider; BrightnessMilliNits is the ioreg
+fallback. Returns a 0.0-1.0 ratio; 1.0 if nothing can be read.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+
+def display_services_ratio() -> float | None:
+    """Control Center / keyboard brightness, 0.0-1.0. None if unavailable."""
+    try:
+        import ctypes
+        from ctypes import POINTER, c_float, c_int, c_uint32
+
+        cg = ctypes.CDLL("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")
+        ds = ctypes.CDLL(
+            "/System/Library/PrivateFrameworks/DisplayServices.framework/DisplayServices"
+        )
+        cg.CGMainDisplayID.restype = c_uint32
+        ds.DisplayServicesGetBrightness.argtypes = [c_uint32, POINTER(c_float)]
+        ds.DisplayServicesGetBrightness.restype = c_int
+        val = c_float()
+        rc = ds.DisplayServicesGetBrightness(cg.CGMainDisplayID(), ctypes.byref(val))
+        if rc == 0 and 0.0 <= val.value <= 1.0:
+            return float(val.value)
+    except Exception:
+        return None
+    return None
+
+
+def ioreg_nits_ratio(out: str) -> float | None:
+    """Parse AppleARMBacklight BrightnessMilliNits value/max from ioreg text."""
+    m = re.search(r'"BrightnessMilliNits"\s*=\s*\{([^}]*)\}', out)
+    if not m:
+        return None
+    body = m.group(1)
+    vm = re.search(r'"value"=(\d+)', body)
+    xm = re.search(r'"max"=(\d+)', body)
+    if not vm or not xm:
+        return None
+    maximum = int(xm.group(1))
+    if maximum <= 0:
+        return None
+    return max(0.0, min(1.0, int(vm.group(1)) / maximum))
+
+
+def system_brightness_ratio() -> float:
+    """Current display brightness as a 0.0-1.0 ratio (falls back to 1.0)."""
+    ratio = display_services_ratio()
+    if ratio is not None:
+        return ratio
+    try:
+        out = subprocess.run(
+            ["/usr/sbin/ioreg", "-rc", "AppleARMBacklight"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        ).stdout
+        nits = ioreg_nits_ratio(out)
+        if nits is not None:
+            return nits
+    except Exception:
+        pass
+    return 1.0

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -3547,6 +3547,35 @@ class AgentMonitorTests(unittest.TestCase):
 
             self.assertEqual((device / "LEDS.LED").read_text(), "brightness 64\n#00FF66")
 
+    def test_ioreg_nits_ratio_parses_value_over_max(self) -> None:
+        from sidepulse.display_brightness import ioreg_nits_ratio
+
+        blob = (
+            '"IODisplayParameters" = {"BrightnessMilliNits"={"min"=3979,'
+            '"value"=381794,"uncalMilliNits"=140000,"max"=1599999},'
+            '"brightness"={"min"=0,"max"=65536,"value"=32768}}'
+        )
+        self.assertAlmostEqual(ioreg_nits_ratio(blob), 381794 / 1599999)
+        self.assertIsNone(ioreg_nits_ratio(""))
+        self.assertIsNone(ioreg_nits_ratio('"brightness"={"min"=0,"max"=65536,"value"=32768}'))
+
+    def test_system_brightness_ratio_prefers_display_services(self) -> None:
+        from sidepulse.display_brightness import system_brightness_ratio
+
+        with patch("sidepulse.display_brightness.display_services_ratio", return_value=0.18):
+            self.assertAlmostEqual(system_brightness_ratio(), 0.18)
+        with patch("sidepulse.display_brightness.display_services_ratio", return_value=None), patch(
+            "sidepulse.display_brightness.subprocess.run"
+        ) as run:
+            run.return_value = SimpleNamespace(
+                stdout='"BrightnessMilliNits"={"min"=0,"value"=25,"max"=100}'
+            )
+            self.assertAlmostEqual(system_brightness_ratio(), 0.25)
+        with patch("sidepulse.display_brightness.display_services_ratio", return_value=None), patch(
+            "sidepulse.display_brightness.subprocess.run", side_effect=OSError("no ioreg")
+        ):
+            self.assertEqual(system_brightness_ratio(), 1.0)
+
     def test_led_count_uses_product_name(self) -> None:
         self.assertEqual(led_count_for_target(Path("/Volumes/SidePulseDot/LEDS.LED")), 2)
         self.assertEqual(led_count_for_target(Path("/Volumes/SidePulsePro/LEDS.LED")), 8)


### PR DESCRIPTION
## What

Add `system_brightness_ratio()` so LED scaling can track the macOS Control Center slider.

AppleARMBacklight's 16-bit `brightness` key sits at 50% (`32768/65536`) on current Macs even when the slider is much lower. DisplayServices matches the slider; `BrightnessMilliNits` is the ioreg fallback.

## Changes
- New `sidepulse.display_brightness` helper, exported as `system_brightness_ratio()`.
- Tests: nits parse, DisplayServices preferred over ioreg, fallback to 1.0 when nothing is readable.
- README note so LED mirroring does not use the 16-bit backlight key.

Does not change animation or color programs — only the brightness scale a caller can apply.

## Verification
- `python3 -m unittest` for the two new `AgentMonitorTests` methods: pass.
- Live: DisplayServices 18% → LED `brightness 46`.