### PR TITLE
Find the event socket across state dirs, and resolve provider icons by app name

### DIFF
--- a/src/sidepulse/ipc.py
+++ b/src/sidepulse/ipc.py
@@ -6,7 +6,7 @@ import threading
 from pathlib import Path
 from typing import Callable
 
-from .providers import default_state_dir
+from .providers import candidate_state_dirs, default_state_dir
 
 
 MAX_EVENT_BYTES = 1024 * 1024
@@ -15,6 +15,11 @@ HOOK_EVENT_SEND_TIMEOUT_SECONDS = 0.2
 
 def default_event_socket_path() -> Path:
     return default_state_dir() / "events.sock"
+
+
+def candidate_event_socket_paths() -> tuple[Path, ...]:
+    """Socket paths a listening app may have bound, most likely first."""
+    return tuple(directory / "events.sock" for directory in candidate_state_dirs())
 
 
 def default_latest_state_path() -> Path:
@@ -28,7 +33,6 @@ def send_hook_event(
     socket_path: Path | None = None,
     timeout: float = HOOK_EVENT_SEND_TIMEOUT_SECONDS,
 ) -> bool:
-    target = (socket_path or default_event_socket_path()).expanduser()
     payload = json.dumps(
         {"provider": provider, "line": line},
         separators=(",", ":"),
@@ -37,6 +41,17 @@ def send_hook_event(
     if len(payload) > MAX_EVENT_BYTES:
         return False
 
+    if socket_path is not None:
+        return _send_payload(socket_path.expanduser(), payload, timeout)
+
+    # The caller and the app can resolve different state dirs, so try each candidate.
+    for target in candidate_event_socket_paths():
+        if _send_payload(target.expanduser(), payload, timeout):
+            return True
+    return False
+
+
+def _send_payload(target: Path, payload: bytes, timeout: float) -> bool:
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.settimeout(timeout)
     try:

--- a/src/sidepulse/models.py
+++ b/src/sidepulse/models.py
@@ -158,4 +158,6 @@ def provider_label(provider: str) -> str:
         "codex": "Codex",
         "claude": "Claude",
         "grok": "Grok",
+        # Lowercase is the product's own spelling, and provider.title() would break it.
+        "opencode": "opencode",
     }.get(provider, provider.title())

--- a/src/sidepulse/providers.py
+++ b/src/sidepulse/providers.py
@@ -95,6 +95,21 @@ def default_state_dir(home: Path | None = None) -> Path:
     return base / ".local" / "state" / "sidepulse" / "agent-monitor"
 
 
+def candidate_state_dirs(home: Path | None = None) -> tuple[Path, ...]:
+    """Every state dir a peer process may have resolved, most likely first.
+
+    ``default_state_dir`` reads ``XDG_STATE_HOME`` from the calling process. Hooks run in
+    the user's shell, while the status bar app runs from a LaunchAgent whose plist forwards
+    only ``PATH`` and ``PYTHONUNBUFFERED``. Whenever the user exports ``XDG_STATE_HOME``,
+    the two processes resolve different directories and never meet.
+    """
+    dirs = [default_state_dir(home)]
+    fallback = (home or Path.home()) / ".local" / "state" / "sidepulse" / "agent-monitor"
+    if fallback not in dirs:
+        dirs.append(fallback)
+    return tuple(dirs)
+
+
 def default_log_path(provider: str, home: Path | None = None) -> Path:
     suffix = "jsonl"
     return default_state_dir(home) / f"{provider}.{suffix}"

--- a/src/sidepulse/status_bar.py
+++ b/src/sidepulse/status_bar.py
@@ -4095,8 +4095,16 @@ def provider_icon_for_provider(provider: str):
     elif provider == "grok":
         image = app_icon("/Applications/Grok.app")
         image = image or grok_badge_icon()
+    elif provider == "opencode":
+        image = app_icon("/Applications/OpenCode.app")
+        image = image or image_for_symbol(
+            "chevron.left.forwardslash.chevron.right", "opencode"
+        )
     else:
-        image = image_for_symbol("terminal", provider.title() or "Agent")
+        # Any other provider resolves its own app by name, so a new agent needs no branch
+        # here. Only providers with an alias or a custom glyph need one.
+        image = provider_app_icon(provider)
+        image = image or image_for_symbol("terminal", provider_label(provider) or "Agent")
     _provider_icon_cache[provider] = image
     return image
 
@@ -4246,6 +4254,21 @@ def grok_badge_icon():
     image.setSize_((18, 18))
     _grok_badge_icon = image
     return image
+
+
+def provider_app_icon(provider: str):
+    """Resolve a provider's own application icon by name.
+
+    LaunchServices matches an application name case-insensitively, so a provider named
+    "opencode" finds OpenCode.app and "ghostty" finds Ghostty.app. This keeps new
+    providers from needing a branch in provider_icon_for_provider. Returns None when no
+    application matches, which includes every provider that is not an installed app.
+    """
+    try:
+        path = NSWorkspace.sharedWorkspace().fullPathForApplication_(provider)
+    except Exception:
+        return None
+    return app_icon(path) if path else None
 
 
 def app_icon(path: str):

--- a/tests/test_sidepulse.py
+++ b/tests/test_sidepulse.py
@@ -570,6 +570,49 @@ class AgentMonitorTests(unittest.TestCase):
             finally:
                 server.stop()
 
+    def test_hook_event_reaches_app_when_xdg_state_home_differs(self) -> None:
+        """A shell hook must still find an app that resolved another state dir.
+
+        The LaunchAgent plist forwards only PATH and PYTHONUNBUFFERED, so the app never
+        sees XDG_STATE_HOME and binds under ~/.local/state. A hook started from the user's
+        shell does see it. Before candidate probing the send failed silently.
+        """
+        # An AF_UNIX path is capped near 104 bytes and the macOS default temp dir is long,
+        # so root this fixture somewhere short.
+        with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+            home = Path(tmp) / "home"
+            app_dir = home / ".local" / "state" / "sidepulse" / "agent-monitor"
+            app_dir.mkdir(parents=True)
+
+            received: list[tuple[str, dict]] = []
+            server = HookEventServer(
+                lambda provider, line: received.append((provider, line)),
+                socket_path=app_dir / "events.sock",
+            )
+            try:
+                server.start()
+                environment = {
+                    "HOME": str(home),
+                    "XDG_STATE_HOME": str(Path(tmp) / "xdg"),
+                }
+                with patch.dict(os.environ, environment):
+                    sent = send_hook_event(
+                        "claude",
+                        {"hook_event_name": "Stop", "session_id": "claude-session"},
+                        timeout=0.5,
+                    )
+
+                deadline = time.time() + 1
+                while sent and not received and time.time() < deadline:
+                    time.sleep(0.01)
+
+                self.assertTrue(sent)
+                self.assertTrue(received)
+                self.assertEqual(received[0][0], "claude")
+                self.assertEqual(received[0][1]["hook_event_name"], "Stop")
+            finally:
+                server.stop()
+
     def test_live_sidepulse_ingests_events_and_persists_latest_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)

--- a/tests/test_status_bar_ui.py
+++ b/tests/test_status_bar_ui.py
@@ -392,9 +392,65 @@ class IconTests(StatusBarTestCase):
                 self.assertIsInstance(sb.session_row_icon_for_status(status), NSImage)
 
     def test_provider_icons_do_not_raise(self):
-        for provider in ("claude", "codex", "grok", "nonsense"):
+        for provider in ("claude", "codex", "grok", "opencode", "nonsense"):
             with self.subTest(provider=provider):
                 sb.provider_icon_for_provider(provider)
+
+    def test_mapped_providers_look_up_their_own_bundle(self):
+        """The generic fallback would absorb a deleted branch without failing.
+
+        provider_app_icon("codex") resolves ChatGPT.app by name on its own, so removing
+        the codex branch still yields an icon and no test notices. Pin the bundle that
+        each explicit branch reads.
+        """
+        wanted = {
+            "codex": "/Applications/Codex.app",
+            "claude": "/Applications/Claude.app",
+            "grok": "/Applications/Grok.app",
+        }
+        for provider, bundle in wanted.items():
+            with self.subTest(provider=provider):
+                looked_up: list[str] = []
+                sb._provider_icon_cache.pop(provider, None)
+                self.addCleanup(sb._provider_icon_cache.pop, provider, None)
+                with patch.object(
+                    sb, "app_icon", lambda path: looked_up.append(path) and None
+                ):
+                    sb.provider_icon_for_provider(provider)
+                self.assertIn(bundle, looked_up)
+
+    def test_unmapped_provider_tries_its_own_app_before_the_glyph(self):
+        """The terminal glyph always returns an image, so it hides a missing lookup.
+
+        Assert that an unmapped provider consults its own application first. Without that
+        step a new agent silently renders as a bare terminal icon.
+        """
+        looked_up: list[str] = []
+        sb._provider_icon_cache.pop("someagent", None)
+        self.addCleanup(sb._provider_icon_cache.pop, "someagent", None)
+        with patch.object(sb, "provider_app_icon", lambda p: looked_up.append(p) and None):
+            image = sb.provider_icon_for_provider("someagent")
+        self.assertEqual(looked_up, ["someagent"])
+        self.assertIsInstance(image, NSImage)
+
+    def test_provider_app_icon_resolves_an_installed_app_by_name(self):
+        """Pin the name matching itself, which is what makes the generic path work."""
+        installed = next(
+            (
+                name
+                for name, path in (
+                    ("opencode", "/Applications/OpenCode.app"),
+                    ("claude", "/Applications/Claude.app"),
+                    ("grok", "/Applications/Grok.app"),
+                )
+                if Path(path).exists()
+            ),
+            None,
+        )
+        if installed is None:  # pragma: no cover
+            self.skipTest("no known agent application installed")
+        self.assertIsInstance(sb.provider_app_icon(installed), NSImage)
+        self.assertIsNone(sb.provider_app_icon("definitely-not-an-installed-app"))
 
     def test_state_symbols_render(self):
         for state in (sb.STATE_IDLE, sb.STATE_WORKING, sb.STATE_DONE, sb.STATE_ASK):


### PR DESCRIPTION
**Two independent commits. Happy to split them, and the first one is the one that matters.**

| Commit | What |
| --- | --- |
| `dde54de` | Bug fix. Hook events are dropped silently when `XDG_STATE_HOME` differs between the app and a hook. Affects Claude, Codex, and Grok users today. |
| `0744c72` | Resolve any provider's icon from its own application instead of a branch per provider. Cosmetic. |

If bundling would hold up the fix, say so and I will move `0744c72` to its own PR.

---

# 1. Event socket path split (`dde54de`)

## The bug

`default_state_dir()` reads `XDG_STATE_HOME` from the **calling process**:

```python
def default_state_dir(home: Path | None = None) -> Path:
    if home is None:
        xdg_state_home = os.environ.get("XDG_STATE_HOME")
        if xdg_state_home:
            return Path(xdg_state_home).expanduser() / "sidepulse" / "agent-monitor"
    base = home or Path.home()
    return base / ".local" / "state" / "sidepulse" / "agent-monitor"
```

Two processes call it and they do not share an environment:

- The status bar app runs from a LaunchAgent. `status_bar_launch.py` sets `EnvironmentVariables` to `PYTHONUNBUFFERED` and `PATH` only, so the app never sees `XDG_STATE_HOME` and binds its socket under `~/.local/state`.
- A hook runs inside Claude Code, Codex, or Grok, in the user's shell. If the user exports `XDG_STATE_HOME`, the hook resolves a different directory.

```mermaid
flowchart LR
    subgraph L["launchd: no XDG_STATE_HOME"]
        A["status bar app<br/>HookEventServer.start()"]
    end
    subgraph U["your shell: XDG_STATE_HOME exported"]
        H["hook<br/>send_hook_event()"]
    end
    A -->|binds| S1["~/.local/state/sidepulse/<br/>agent-monitor/events.sock"]
    H -->|connects| S2["$XDG_STATE_HOME/sidepulse/<br/>agent-monitor/events.sock"]
    S2 --> D["no listener<br/>returns False<br/>hook_log_main discards it"]
    D --> X["event dropped, no error anywhere"]
```

Every hook event is then dropped. `send_hook_event` returns `False`, and `hook_log_main` discards that value:

```python
if not hook_event_socket_disabled():
    send_hook_event(actual_provider, line)   # return value ignored
```

The failure is silent. The menu bar holds the last state, and nothing is logged. This also puts the JSONL under the hook's directory, so the log fallback misses it too.

`test_hook_stability.py` already names this contract:

> **Still actually work.** Fail-open is only acceptable if the happy path genuinely logs -- otherwise "return 0" would pass these tests while silently recording nothing.

## Reproduction

Using the shipped `HookEventServer` and `send_hook_event`, in two processes, provider `claude`.

Both agree, variable unset everywhere:

```
client target = /Users/me/.local/state/sidepulse/agent-monitor/events.sock
send_hook_event returned True
server bound  = /Users/me/.local/state/sidepulse/agent-monitor/events.sock
server got    = 1 event(s)
```

App started without the variable, hook started with it:

```
client XDG_STATE_HOME = /Users/me/Library/Application Support/some.app
client target = /Users/me/Library/Application Support/some.app/sidepulse/agent-monitor/events.sock
send_hook_event returned False
server bound  = /Users/me/.local/state/sidepulse/agent-monitor/events.sock
server got    = 0 event(s)
```

I hit this because the opencode desktop app exports a per-application `XDG_STATE_HOME` to its child processes. Any user who sets the variable in a shell profile reaches the same result.

## The fix

Add `candidate_state_dirs()` next to `default_state_dir()`, and probe each candidate socket in `send_hook_event` when the caller passes no explicit `socket_path`. An explicit `socket_path` keeps its exact previous behavior, so existing tests are untouched.

```mermaid
flowchart LR
    H["send_hook_event()"] --> C{"candidate_event_socket_paths()"}
    C -->|"try 1"| S2["$XDG_STATE_HOME/...<br/>events.sock"]
    S2 -->|"no listener"| S1["~/.local/state/...<br/>events.sock"]
    S1 -->|"connected"| A["status bar app"]
    C -->|"explicit socket_path<br/>given by a caller"| P["used alone,<br/>previous behavior"]
```

The change is 34 lines across two files, with no new dependency.

## Tests

New regression test `test_hook_event_reaches_app_when_xdg_state_home_differs` binds the server under a fake `HOME` and sends with `XDG_STATE_HOME` pointing elsewhere. It fails on `main` with `AssertionError: False is not true` and passes with this change.

Full suite: 289 tests, 1 failure. That failure is `test_claude_compat_grok_payload_routes_to_grok_log`, which expects `agent_origin == "Grok CLI"` and gets `"Grok in VS Code"`. It fails on clean `main` in my environment too, so it is unrelated to this change. Origin detection appears to read the parent process, which makes that test sensitive to the terminal it runs in.

## Out of scope

`detect_log_path()` derives the JSONL path from the same function and has the same split. The socket is the live channel the app consumes, so fixing it restores function. Say the word if you want the log path probed the same way in this PR.

---

# 2. Provider icons (`0744c72`)

`provider_icon_for_provider` matches `codex`, `claude`, and `grok`; everything else falls through to a bare `terminal` glyph. Since the ingest path accepts any provider name, an agent that speaks the event socket already shows up in the menu with no icon of its own.

Rather than add a branch per agent, resolve the application by name:

```python
path = NSWorkspace.sharedWorkspace().fullPathForApplication_(provider)
```

LaunchServices matches case-insensitively, so `opencode` finds `OpenCode.app` and `ghostty` finds `Ghostty.app`, while an unknown name returns `None`. A future provider needs no change to this function at all. The three existing branches stay, because they carry an alias (`ChatGPT.app`) or a custom glyph that name matching does not reproduce.

One provider-specific line remains, in `provider_label`: `provider.title()` renders `Opencode`, and the product spells itself lowercase.

## The risk this introduces, and the test for it

The generic path can mask a deleted branch. `fullPathForApplication_("codex")` resolves `/Applications/ChatGPT.app` unaided, so removing the codex branch still yields an icon, and `test_provider_icons_do_not_raise` stays green because the `else` fallback always returns an `NSImage`. Verified by deleting the branch:

```
AssertionError: '/Applications/Codex.app' not found in ['/Applications/ChatGPT.app']
```

Three tests:

- `test_mapped_providers_look_up_their_own_bundle` pins the bundle each explicit branch reads, including `Codex.app`.
- `test_unmapped_provider_tries_its_own_app_before_the_glyph` pins the generic path.
- `test_provider_app_icon_resolves_an_installed_app_by_name` pins the name matching itself, and skips when no agent app is installed.

Suite with both commits: 292 tests, still only the pre-existing `test_claude_compat_grok_payload_routes_to_grok_log` failure described above.

## Client note for anyone writing a non-Python hook

`Bun.connect` is unreachable from an npm-installed opencode plugin, so my first client failed silently. `node:net` works under any runtime, and `end(payload)` produces the FIN that `_handle_connection` waits for. That was my bug, not yours, but it may save the next person some time if you ever document the socket.


